### PR TITLE
chore: add capabilities.md with cap reference docs

### DIFF
--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -12,7 +12,7 @@ A capability consists of several components:
 
 In the definitions below, we identify capabilities by the ability name, which is used by the service provider to route invocations to the correct handler. The definitions include what kinds of resource URI are acceptable, as well as optional and required caveats that can be included in an invocation.
 
-The caveats are used for two complementary purposes. When used in an invocation, they act as "function parameters" for the remote procedure call, giving the capability provider the context they need to fulfil the request. For example, the `link` caveat in a `store/add` invocation specifies the CID of the CAR to be stored.
+The caveats are used for two complementary purposes. When used in an invocation, they act as "function parameters" for the remote procedure call, giving the capability provider the context they need to fulfill the request. For example, the `link` caveat in a `store/add` invocation specifies the CID of the CAR to be stored.
 
 When used in a delegation, caveats act as constraints on the values allowed in an invocation. For example, if a `store/add` delegation has a `size` caveat of 10MB, your invocation's `size` caveat must be less than or equal to 10MB.
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -30,19 +30,63 @@ There may be multiple delegations in a chain, for example: service `A` issues a 
 
 The `account/` namespace contains capabilities related to account identification and recovery.
 
+Note that we have recently begun referring to accounts as "memory spaces," because the word "account" has many meanings, none of which map precisely to our use case. The capabilities related to memory spaces still use the  `account/` namespace, but this may change in the future. If so, this doc will be updated to reflect the change.
+
 The `account/*` capability contains (can derive) all abilities in the `account/` namespace, so long as the derived capability has the same resource URI.
 
 ### `account/info`
 
-> Request information about an account DID.
+> Request information about a memory space DID.
 
-The `account/info` capability can be invoked to request information about a user account. The `with` resource URI identifies the user account, usually with a `did:key` URI.
+The `account/info` capability can be invoked to request information about a "memory space". The `with` resource URI identifies the space, usually with a `did:key` URI.
 
 See [services.md](./services.md) for a description of the result type and possible errors.
 
+#### Derivations
+
+`account/info` can be derived from an `account/*` or `*` capability with a matching `with` field.
+
+It can also be derived from any of the capabilities in the `store/` namespace, including [`store/*`](#store).
+
+#### Caveats
+
+`account/info` has no defined caveats.
+
 ### `account/recover`
 
+> Obtain a replacement capability delegation.
+
+In the event that an agent loses the UCAN that encodes their capability delegations for a memory space (e.g. due to accidental deletion, disk corruption, etc.), they may invoke the `account/recover` capability to obtain a new delegation of the capabilities they previously had access to.
+
+The `with` resource URI of the `account/recover` invocation must contain the DID of the memory space that the agent is attempting to recover access to.
+
+The invocation must contain proof that the agent possesses the `account/recover` capability. As the agent is presumably attempting to recover because they have lost their proofs, this implies that the service must have a way to verify the identity of the agent "out of band" (not using UCAN proofs).
+
+See the [`account/recover-validation`](#accountrecover-validation) capability for more on identity validation.
+
+#### Derivations
+
+`account/recover` can be derived from an `account/*` or `*` capability with an equal `with` field.
+
+#### Caveats
+
+`account/recover` has no defined caveats.
+
 ### `account/recover-validation`
+
+> Validate a registered external identity to initiate the recovery process.
+
+If an agent loses the UCAN that encodes their capability delegations for a memory space, they can initiate a recovery process by invoking the `account/recover-validation` capability.
+
+This is one of the few capabilities that can be invoked without inlcuding proof of delegation, as it is intended to be used when proofs have been lost. <!-- TODO: is this true? verify w/Hugo -->
+
+Instead, the service provider will verify a registered external identity (e.g. email), and will issue a delegation for the `account/recover` capability after verification is complete.
+
+#### Caveats
+
+The `account/recover-validation` invocation must include an `email` caveat containing an email address that has been previously registered (e.g. using [`voucher/redeem`](#voucherredeem)).
+
+In the future, the capability may allow validation of other types of external identity besides email. This doc will be updated to include the proper caveats when that change happens.
 
 ## CAR storage
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -36,9 +36,13 @@ The `account/*` capability contains (can derive) all abilities in the `account/`
 
 > Request information about an account DID.
 
-### `account/recover-validation`
+The `account/info` capability can be invoked to request information about a user account. The `with` resource URI identifies the user account, usually with a `did:key` URI.
+
+See [services.md](./services.md) for a description of the result type and possible errors.
 
 ### `account/recover`
+
+### `account/recover-validation`
 
 ## CAR storage
 
@@ -89,7 +93,7 @@ Fields marked as "required" below must be present in the invocation, but may be 
 
 | field       | value         | required? | context                                                             |
 | ----------- | ------------- | --------- | ------------------------------------------------------------------- |
-| `can`       | `store/add`   | ✅         | The ability to add CAR data to an account.                          |
+| `can`       | `store/add`   | ✅         | The ability to add CAR data to a memory space.                      |
 | `with`      | `did:*`       | ✅         | The `did:key` URI for the CAR's destination memory space            |
 | `nb.link`   | `bagk123...`  | ✅         | CID of CAR that the user wants to store                             |
 | `nb.origin` | `bagkabc...`  | ⛔         | Optional link to related CARs. See below for more details.          |
@@ -101,9 +105,23 @@ The `nb.origin` field may be set to provide a link to a related CAR file. This i
 
 > Remove a stored CAR
 
-The `store/remove` capability can be invoked to remove the association between a previously stored CAR and an account.
+The `store/remove` capability can be invoked to remove a CAR file from a memory space, identified by the resource URI in the `with` field. 
 
+This may or may not cause the CAR to be removed completely from Elastic IPFS; for example, if the CAR exists in other memory spaces, it will not be removed. 
 
+`store/remove` will remove the CAR from the listing provided by [`store/list`](#storelist) for the memory space. Removal may also have billing implications, depending on the service provider (e.g. by affecting storage quotas).
+
+#### Derivations
+
+`store/remove` can be derived from a `store/*` or `*` capability with a matching `with` field.
+
+#### Caveats
+
+When invoking `store/remove`, the `link` caveat must be set to the CID of the CAR file to remove. 
+
+If a delegation contains a `link` caveat, an invocation derived from it must have the same CAR CID in it's `link` field. A delegation without a `link` caveat may be invoked with any `link` value.
+
+#### Invocation
 
 ```js
 {
@@ -114,6 +132,12 @@ The `store/remove` capability can be invoked to remove the association between a
   }
 }
 ```
+
+| field     | value          | required? | context                                             |
+| --------- | -------------- | --------- | --------------------------------------------------- |
+| `can`     | `store/remove` | ✅         | The ability to remove CAR data from a memory space. |
+| `with`    | `did:*`        | ✅         | The `did:key` URI for the CAR's memory space        |
+| `nb.link` | `bag...`       | ✅         | The CID of the CAR file to remove                   |
 
 ### `store/list`
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -1,5 +1,31 @@
 # Capabilities
 
+This reference doc contains details about each capability defined in the w3-protocol suite of services. It does not specify the exact RPC semantics for each service, for example, result schemas, possible error conditions, etc. See [services.md](./services.md) for those details. 
+
+## About the definitions
+
+A capability consists of several components:
+
+- The **ability** is the "verb" of the capability, describing the action an agent can perform. For example, `store/add` allows adding CAR files to the store. Abilities are encoded into the `can` field in a UCAN delegation or invocation.
+- The **resource** is the "noun" of the capability, describing something that an agent is trying to perform an action _on_. Resources are URIs and are encoded into the `with` field of a UCAN.
+- The **caveats** are qualifiers that can constrain delegations or parameterize invocations. See below for more details. Caveats are encoded into the `nb` object field of a UCAN.
+
+In the definitions below, we identify capabilities by the ability name, which is used by the service provider to route invocations to the correct handler. The definitions include what kinds of resource URI are acceptable, as well as optional and required caveats that can be included in an invocation.
+
+The caveats are used for two complementary purposes. When used in an invocation, they act as "function parameters" for the remote procedure call, giving the capability provider the context they need to fulfil the request. For example, the `link` caveat in a `store/add` invocation specifies the CID of the CAR to be stored.
+
+When used in a delegation, caveats act as constraints on the values allowed in an invocation. For example, if a `store/add` delegation has a `size` caveat of 10MB, your invocation's `size` caveat must be less than or equal to 10MB.
+
+### Issuer and audience
+
+UCANs have a notion of "issuer" and "audience", represented by the `iss` and `aud` fields.
+
+In an invocation, the audience is the service provider, and the issuer is the agent that is making the request.
+
+In a delegation, the audience is the agent who is being delegated _to_, and the issuer is an agent who already posesses the capability and is delegating to the audience. In the common case of a single delegation from service provider to user agent, the service would be the issuer, and the user agent would be the audience. 
+
+There may be multiple delegations in a chain, for example: service `A` issues a delegation to service `B` as the audience, followed by service `B` issuing a delegation to user agent `U` as the audience. To exercise the capability, `U` would issue an invocation with `A` as the audience and include the delegation chain as proof of authorization.
+
 ## Accounts
 
 The `account/` namespace contains capabilities related to account identification and recovery.
@@ -8,9 +34,7 @@ The `account/*` capability contains (can derive) all abilities in the `account/`
 
 ### `account/info`
 
-Request information about an account DID.
-
-
+> Request information about an account DID.
 
 ### `account/recover-validation`
 
@@ -22,17 +46,33 @@ The `store/` namespace contains capabilities relating to storage of CAR files.
 
 This is distinct from the `upload/` namespace, which associates root "data" CIDs with one or more CARs.
 
-### `store/add` - store a CAR and associate it with an account
+The resource URI used in the `store/` capabilities is a `did:key` URI that identifies a "memory space" that acts as a destination for the stored CARs. A memory space is analagous to a bucket in S3 in that it has a unique id, groups stored objects for "directory listing" and usage/quota tracking, and is associated with a user account.
 
-The `store/add` capability can be invoked to store a CAR file with the service.
+### `store/*`
 
-The stored CAR will be associated with the account identified by the `with` resource URI.
+The `store/*` capability can be delegated to a user agent, but cannot be invoked directly. Instead, it allows the audience to derive any capability in the `store/` namespace, provided the resource URI matches the one in the `store/*` capability delegation.
 
-When invoking the capability, the user must specify the CAR CID in the `link` caveat field. 
+The `store/*` capability (and all capabilities in the `store/` namespace) can be derived from a `*` "super user" capability with a matching resource URI.
 
-If a capability delegation includes the `link` caveat, the user's invocation must contain a matching `link` caveat with an equal CID value. If the delegation does not have a `link` caveat, the user may set `link` to any valid CAR CID.
+### `store/add` 
 
-If a delegation includes the `size` caveat, the invocation must also include a `size` caveat with a value `<=` the delegated `size`. The `size` field in the invocation should match the size of the CAR to be stored.
+> Store a CAR file
+
+The `store/add` capability allows an agent to store a CAR file into the memory space identified by the `did:key` URI in the `with` field. The agent must precompute the CAR locally and provide the CAR's CID and size using the `nb.link` and `nb.size` fields, allowing a service to provision a write location for the agent to `PUT` or `POST` the CAR into.
+
+#### Derivations
+
+`store/add` can be derived from a `store/*` or `*` capability with a matching `with` field.
+
+#### Caveats
+
+It is possible for a service to issue a `store/add` delegation with a `link` caveat, which would restrict the user to only storing a specific CID. This is not terribly useful, however, so delegations are unlikely to contain a `link` restriction.
+
+The `size` caveat is much more likely to be included in a delegation, as service providers may want to limit the maximum CAR size that they will accept. Agents should check their delegation's `nb.size` field and ensure that they only send CARs with a size below the limit. If `nb.size` is set in the delegation, the agent must include an `nb.size` field in their invocation, with a value that is `<=` the limit set in the delegation's `nb.size` field.
+
+#### Invocation
+
+Example:
 
 ```js
 {
@@ -40,19 +80,26 @@ If a delegation includes the `size` caveat, the invocation must also include a `
   with: "did:key:abc...",
   nb: {
     link: "bag...",
+    size: 1234
   }
 }
 ```
 
-| field       | value         | context                                                             |
-| ----------- | ------------- | ------------------------------------------------------------------- |
-| `can`       | `store/add`   | The ability to add CAR data to an account.                          |
-| `with`      | `did:*`       | The `with` resource URI must have a `did` scheme                    |
-| `nb.link`   | `bag...`      | CID of CAR that the user wants to store                             |
-| `nb.origin` | ?             | Not sure... FIXME(@hugomrdias): can you add some context here?      |
-| `nb.size`   | size in bytes | If the `size` caveat is present, the uploaded CAR must be `<= size` |
+Fields marked as "required" below must be present in the invocation, but may be absent in capability delegations. 
 
-### `store/remove` - remove the association between a stored CAR and an account
+| field       | value         | required? | context                                                             |
+| ----------- | ------------- | --------- | ------------------------------------------------------------------- |
+| `can`       | `store/add`   | ✅         | The ability to add CAR data to an account.                          |
+| `with`      | `did:*`       | ✅         | The `did:key` URI for the CAR's destination memory space            |
+| `nb.link`   | `bagk123...`  | ✅         | CID of CAR that the user wants to store                             |
+| `nb.origin` | `bagkabc...`  | ⛔         | Optional link to related CARs. See below for more details.          |
+| `nb.size`   | size in bytes | ✅         | If the `size` caveat is present, the uploaded CAR must be `<= size` |
+
+The `nb.origin` field may be set to provide a link to a related CAR file. This is useful when storing large DAGs that are sharded across multiple CAR files. In this case, the agent can link each uploaded shard with a previous one. Providing the `origin` field informs the service that the CAR being stored is a shard of the larger DAG, as opposed to an intentionally partial DAG. 
+
+### `store/remove` 
+
+> Remove a stored CAR
 
 The `store/remove` capability can be invoked to remove the association between a previously stored CAR and an account.
 
@@ -70,6 +117,8 @@ The `store/remove` capability can be invoked to remove the association between a
 
 ### `store/list`
 
+> Obtain a list of stored CARs
+
 ## `upload/*` namespace
 
 Capabilities relating to "uploads", which consist of a root CID for some content, as well as links the the CARs containing the content blocks.
@@ -86,26 +135,6 @@ Capabilities relating to "uploads", which consist of a root CID for some content
 ### `voucher/claim`
 
 Request a voucher that can be redeemed to activate features and/or products for an account or agent DID.
-
-| Ability         | Resource             |
-| --------------- | -------------------- |
-| `voucher/claim` | Account or agent DID |
-
-Caveats:
-
-| Name | Type                         | Description                                                        |
-| ---- | ---------------------------- | ------------------------------------------------------------------ |
-| `of` | `ProductLink`                | CID referencing `Product` definition object                        |
-| `by` | `VerifiableID` / `MailtoURI` | URL that corresponds to the verifiable identity submitting a claim |
-| `at` | `ServiceDID`                 | DID of the service that will redeem the voucher                    |
-
-**Return value**: A UCAN that delegates the `voucher/redeem` ability to the `issuer` of the claim, after their `VerifiableID` has in fact been verified.
-
-**Error types**:
-
-- `ProductError`
-- `IdentityError`
-- `AccountError`
 
 ### `voucher/redeem`
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -222,15 +222,51 @@ The `root` caveat must contain the root CID of the data item to remove.
 
 ### `upload/list`
 
-TODO
+> Obtain a list of uploaded data items.
 
-## `voucher/*` namespace
+The `upload/list` capability can be invoked to request a list of metadata about uploads. See [services.md](./services.md#uploadlist) for details about the response.
 
-TODO
+The `with` field of the invocation must be set to the DID of the memory space to be listed.
+
+#### Derivations
+
+`upload/list` can be derived from a `upload/*` or `*` capability with a matching `with` field.
+
+#### Caveats
+
+None currently, but this is expected to change once pagination is fully implemented.
+
+## `voucher/` namespace
+
+TODO: more voucher docs when implementation details settle down a bit.
 
 ### `voucher/claim`
 
 Request a voucher that can be redeemed to activate features and/or products for an account or agent DID.
 
+<!-- 
+
+TODO: add context here:
+- what are valid product URIs? Or is that an opaque detail for the caller?
+- is `identity` always a mailto: URI? 
+- double check that `with` URI should be the DID of the service
+
+-->
+
+#### Caveats
+
+| field         | value                             | required? | context                                                              |
+| ------------- | --------------------------------- | --------- | -------------------------------------------------------------------- |
+| `can`         | `voucher/claim`                   | ✅         | The ability to claim a voucher.                                      |
+| `with`        | DID string, e.g. `did:key:123...` | ✅         | The DID of the service offering the product                          |
+| `nb.product`  | URI string with `product:` scheme | ✅         | A URI identifying the product                                        |
+| `nb.identity` | string, e.g. `mailto:`            | ✅         |                                                                      |
+| `nb.account`  | DID string                        | ✅         | The DID of the memory space or account that will receive the product |
+
 ### `voucher/redeem`
 
+Redeeem a voucher to activate features / products for an account or agent DID.
+
+<!--
+TODO: document this. currently, the implementation ignores caveats & creates a new account for every successful redemption. Might be changing?
+-->

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -1,0 +1,111 @@
+# Capabilities
+
+## Accounts
+
+The `account/` namespace contains capabilities related to account identification and recovery.
+
+The `account/*` capability contains (can derive) all abilities in the `account/` namespace, so long as the derived capability has the same resource URI.
+
+### `account/info`
+
+Request information about an account DID.
+
+
+
+### `account/recover-validation`
+
+### `account/recover`
+
+## CAR storage
+
+The `store/` namespace contains capabilities relating to storage of CAR files.
+
+This is distinct from the `upload/` namespace, which associates root "data" CIDs with one or more CARs.
+
+### `store/add` - store a CAR and associate it with an account
+
+The `store/add` capability can be invoked to store a CAR file with the service.
+
+The stored CAR will be associated with the account identified by the `with` resource URI.
+
+When invoking the capability, the user must specify the CAR CID in the `link` caveat field. 
+
+If a capability delegation includes the `link` caveat, the user's invocation must contain a matching `link` caveat with an equal CID value. If the delegation does not have a `link` caveat, the user may set `link` to any valid CAR CID.
+
+If a delegation includes the `size` caveat, the invocation must also include a `size` caveat with a value `<=` the delegated `size`. The `size` field in the invocation should match the size of the CAR to be stored.
+
+```js
+{
+  can: "store/add",
+  with: "did:key:abc...",
+  nb: {
+    link: "bag...",
+  }
+}
+```
+
+| field       | value         | context                                                             |
+| ----------- | ------------- | ------------------------------------------------------------------- |
+| `can`       | `store/add`   | The ability to add CAR data to an account.                          |
+| `with`      | `did:*`       | The `with` resource URI must have a `did` scheme                    |
+| `nb.link`   | `bag...`      | CID of CAR that the user wants to store                             |
+| `nb.origin` | ?             | Not sure... FIXME(@hugomrdias): can you add some context here?      |
+| `nb.size`   | size in bytes | If the `size` caveat is present, the uploaded CAR must be `<= size` |
+
+### `store/remove` - remove the association between a stored CAR and an account
+
+The `store/remove` capability can be invoked to remove the association between a previously stored CAR and an account.
+
+
+
+```js
+{
+  can: "store/remove",
+  with: "did:key:abc...",
+  nb: {
+    link: "bag...",
+  }
+}
+```
+
+### `store/list`
+
+## `upload/*` namespace
+
+Capabilities relating to "uploads", which consist of a root CID for some content, as well as links the the CARs containing the content blocks.
+
+### `upload/add`
+
+### `upload/remove`
+
+### `upload/list`
+
+
+## `voucher/*` namespace
+
+### `voucher/claim`
+
+Request a voucher that can be redeemed to activate features and/or products for an account or agent DID.
+
+| Ability         | Resource             |
+| --------------- | -------------------- |
+| `voucher/claim` | Account or agent DID |
+
+Caveats:
+
+| Name | Type                         | Description                                                        |
+| ---- | ---------------------------- | ------------------------------------------------------------------ |
+| `of` | `ProductLink`                | CID referencing `Product` definition object                        |
+| `by` | `VerifiableID` / `MailtoURI` | URL that corresponds to the verifiable identity submitting a claim |
+| `at` | `ServiceDID`                 | DID of the service that will redeem the voucher                    |
+
+**Return value**: A UCAN that delegates the `voucher/redeem` ability to the `issuer` of the claim, after their `VerifiableID` has in fact been verified.
+
+**Error types**:
+
+- `ProductError`
+- `IdentityError`
+- `AccountError`
+
+### `voucher/redeem`
+

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -143,6 +143,18 @@ If a delegation contains a `link` caveat, an invocation derived from it must hav
 
 > Obtain a list of stored CARs
 
+The `store/list` capability can be invoked to request a list of CARs in a given memory space.
+
+The `with` field of the invocation must be set to the DID of the memory space to be listed.
+
+#### Derivations
+
+`store/list` can be derived from a `store/*` or `*` capability with a matching `with` field.
+
+#### Caveats
+
+None currently, but this is expected to change once pagination is fully implemented.
+
 ## `upload/*` namespace
 
 Capabilities relating to "uploads", which consist of a root CID for some content, as well as links the the CARs containing the content blocks.

--- a/spec/services.md
+++ b/spec/services.md
@@ -83,7 +83,7 @@ On success, the service returns an `Account` object with the following fields:
 
 #### Errors
 
-TODO: describe possible error types, how to distinguish between them
+May fail with a `MalformedCapability` if the account does not exist.
 
 ### `account/recover`
 
@@ -124,7 +124,7 @@ If the response contains `url` and `headers` fields, the client should issue an 
 
 #### Errors
 
-TODO: list possible error types
+May fail with a `MalformedCapability` if no `link` caveat is provided.
 
 ### `store/remove`
 
@@ -142,7 +142,7 @@ On success, the service will echo back the CID of the removed CAR, as a string.
 
 #### Errors
 
-TODO: list possible errors
+May fail with a `MalformedCapability` if no `link` caveat is provided.
 
 ### `store/list`
 
@@ -204,7 +204,7 @@ The current implementation returns `null` on success, but this may be changed in
 
 #### Errors
 
-TODO: list error types
+May fail with a `MalformedCapability` if no `root` CID caveat is provided, or if the `shards` caveat is missing or contains an empty array.
 
 ### `upload/remove`
 
@@ -222,7 +222,7 @@ The service currently returns no value on success.
 
 #### Errors
 
-TODO: list errors
+May fail with a `MalformedCapability` if no `root` CID caveat was provided.
 
 ### `upload/list`
 

--- a/spec/services.md
+++ b/spec/services.md
@@ -42,8 +42,8 @@ On success, the service returns an `Account` object with the following fields:
 | `agent`       | `string` | The DID of the primary agent associated with the account    |
 | `email`       | `string` | The email registered to the account                         |
 | `product`     | `string` | `product:` URI of product registered to the account, if any |
-| `updated_at`  | `string` | ISO timestamp? TODO: check this :)                          |
-| `inserted_at` | `string` | see above...                                                |
+| `updated_at`  | `string` | ISO 8601 timestamp of last update to account record         |
+| `inserted_at` | `string` | ISO 8601 timestamp of account record creation               |
 
 #### Errors
 
@@ -72,13 +72,13 @@ The invocation must also include a `size` caveat set to the size of the CAR in b
 
 On success, the service will return an object containing status information, possibly including a signed URL for uploading CAR data.
 
-| field         | type     | description                                                 |
-| ------------- | -------- | ----------------------------------------------------------- |
-| `status` | `string` | One of `"upload"` or `"done"`, depending on whether the CAR is new to the service (see below) |
-| `with` | `string` | The DID of the memory space the CAR was added to |
-| `link` | `CID` | The CID of the added CAR file |
-| `url` | `string` | URL to send CAR data to. Only present if `status == "upload"` |
-| `headers` | `Record<string, string>` | Headers to include in POST request when sending CAR data. Only present if `status == "upload"`
+| field     | type                     | description                                                                                    |
+| --------- | ------------------------ | ---------------------------------------------------------------------------------------------- |
+| `status`  | `string`                 | One of `"upload"` or `"done"`, depending on whether the CAR is new to the service (see below)  |
+| `with`    | `string`                 | The DID of the memory space the CAR was added to                                               |
+| `link`    | `CID`                    | The CID of the added CAR file                                                                  |
+| `url`     | `string`                 | URL to send CAR data to. Only present if `status == "upload"`                                  |
+| `headers` | `Record<string, string>` | Headers to include in POST request when sending CAR data. Only present if `status == "upload"` |
 
 If the CID in the invocation's `link` caveat already exists on the service, e.g. because it was previously added by another agent, the `status` field in the response will be `"done"`, and the response will not include a URL for uploading.
 
@@ -86,9 +86,63 @@ If the CAR has not been previously added, the `status` field will contain `"uplo
 
 If the response contains `url` and `headers` fields, the client should issue an HTTP `POST` request to the URL and include the headers. The request body must be the CAR data, whose size and CID must match those in the invocation.
 
+#### Errors
+
+TODO: list possible error types
+
 ### `store/remove`
 
+Provides the [`store/remove` capability](./capabilities.md#storeremove), which removes the association between a CAR file and a memory space.
+
+#### Invocation
+
+The invocation's `with` field must be set to the DID of the memory space where the CAR is currently stored, and the caller must provide proof that they possess the `store/remove` capability for that space.
+
+The invocation's `link` caveat must be set to the CID of the CAR to be removed.
+
+#### Response
+
+On success, the service will echo back the CID of the removed CAR, as a string.
+
+#### Errors
+
+TODO: list possible errors
+
 ### `store/list`
+
+Provides the [`store/list` capability](./capabilities.md#storelist), which returns a list of stored CAR files for a given memory space.
+
+#### Invocation
+
+The invocation's `with` field must be set to the DID of the memory space to be listed, and the caller must provide proof that they posess the `store/list` capability for that space.
+
+Note that caveats for pagination will be added in the near future.
+
+#### Response
+
+On success, returns an object whose `results` field contains an array of `StoreItem` metadata objects for each stored CAR.
+
+A `StoreItem` has the following fields:
+
+| field            | type             | description                                                    |
+| ---------------- | ---------------- | -------------------------------------------------------------- |
+| `uploaderDID`    | `string`         | The DID of the agent who uploaded the CAR                      |
+| `payloadCID`     | `string` (`CID`) | The CID of the CAR                                             |
+| `applicationDID` | `string`         | Reserved for future use                                        |
+| `origin`         | `string` (`CID`) | Link from this CAR to another shard of the same DAG (optional) |
+| `proof`          | `string`         | Encoded UCAN of proof included with upload invocation          |
+| `size`           | `number`         | Size of CAR data in bytes                                      |
+| `uploadedAt`     | `string`         | ISO 8601 timestamp of upload                                   |
+
+The full response object returned by `store/list` currently looks like this, although there may be changes when pagination is fully implemented. Currently, the service always returns all results in a single "page".
+
+| field      | type          | description                                               |
+| ---------- | ------------- | --------------------------------------------------------- |
+| `count`    | `number`      | The total number of CARs in the memory space              |
+| `pages`    | `number`      | The number of pages available in the listing              |
+| `page`     | `number`      | The index of the current page of results                  |
+| `pageSize` | `number`      | The max number of results in each page                    |
+| `results`  | `StoreItem[]` | An array of `StoreItem`s (see above) for the current page |
 
 ## Uploads service
 

--- a/spec/services.md
+++ b/spec/services.md
@@ -1,0 +1,33 @@
+# Service definitions
+
+This doc collects RPC interface definitions for the `w3-protocol` services.
+
+## What is a Service?
+
+We're using [ucanto](https://github.com/web3-storage/ucanto) to model services as a collection of related capabilities, which can be "invoked" by a user agent to perform some action and/or make a request.
+
+Capabilites are defined in terms of **abilities** and **resources**. 
+
+The **ability** is a string identifying some "verb," or action that can be performed. Ability strings have a format of `namespace/action`, for example, `account/info`.
+
+A **resource** is something that can be acted upon, identified by a URI. In w3-protocol services, many of the resource URIs will be `did:` URIs that identify a user account. 
+
+A `ucanto` service takes in a stream of "invocations," which you can think of as serialized RPC requests that are encoded as UCANs and signed by the caller. An invocation must contain a proof that the capability being invoked has been delegated to the caller.
+
+A `ucanto` service uses the ability string to dispatch an invocation to the correct "capability provider" function, which executes some logic and (optionally) returns some result to the caller.
+
+A capability invocation can contain "parameters", which are encoded into the UCAN's "caveats" (`nb` field in the JWT form).
+
+TODO: clarify that delegations with caveats act as constraints (see https://www.notion.so/Protocol-Specifications-aa31a64a587c4d02bfacac144d155783)
+
+## Accounts service
+
+### `account/info`
+
+### `account/recover`
+
+### `account/recover-validation`
+
+
+## Storage service
+

--- a/spec/services.md
+++ b/spec/services.md
@@ -2,27 +2,50 @@
 
 This doc collects RPC interface definitions for the `w3-protocol` services.
 
+See [capabilities.md](./capabilities.md) for details about each of the capablities defined in the protocol. This doc builds upon those definitions and includes the result types and possible error cases for the implementation of each capability handler in our services. Third parties that want to provide an alternate implementation are encouraged to use compatible result and error types where possible.
+
 ## What is a Service?
 
 We're using [ucanto](https://github.com/web3-storage/ucanto) to model services as a collection of related capabilities, which can be "invoked" by a user agent to perform some action and/or make a request.
 
-Capabilites are defined in terms of **abilities** and **resources**. 
+Capabilities are defined in terms of **abilities** and **resources**. 
 
 The **ability** is a string identifying some "verb," or action that can be performed. Ability strings have a format of `namespace/action`, for example, `account/info`.
 
-A **resource** is something that can be acted upon, identified by a URI. In w3-protocol services, many of the resource URIs will be `did:` URIs that identify a user account. 
+A **resource** is something that can be acted upon, identified by a URI. In w3-protocol services, many of the resource URIs will be `did:` URIs that identify a user account or storage location.
 
-A `ucanto` service takes in a stream of "invocations," which you can think of as serialized RPC requests that are encoded as UCANs and signed by the caller. An invocation must contain a proof that the capability being invoked has been delegated to the caller.
+Capabilities may also contain **caveats**, which act like function parameters when used in an invocation.
+
+A `ucanto` service takes in a stream of invocations, which you can think of as serialized RPC requests that are encoded as UCANs and signed by the caller. An invocation must contain a proof that the capability being invoked has been delegated to the caller.
 
 A `ucanto` service uses the ability string to dispatch an invocation to the correct "capability provider" function, which executes some logic and (optionally) returns some result to the caller.
 
-A capability invocation can contain "parameters", which are encoded into the UCAN's "caveats" (`nb` field in the JWT form).
-
-TODO: clarify that delegations with caveats act as constraints (see https://www.notion.so/Protocol-Specifications-aa31a64a587c4d02bfacac144d155783)
+See [capabilities.md](./capabilities.md) for more details about capabilities, including the optional and required caveats for each.
 
 ## Accounts service
 
 ### `account/info`
+
+Provides the [`account/info` capability](./capabilities.md#accountinfo).
+
+The `with` field of the invocation must contain the `did:` URI for the account to be identified.
+
+#### Response
+
+On success, the service returns an `Account` object with the following fields:
+
+| field         | type     | description                                                 |
+| ------------- | -------- | ----------------------------------------------------------- |
+| `did`         | `string` | The DID of the account                                      |
+| `agent`       | `string` | The DID of the primary agent associated with the account    |
+| `email`       | `string` | The email registered to the account                         |
+| `product`     | `string` | `product:` URI of product registered to the account, if any |
+| `updated_at`  | `string` | ISO timestamp? TODO: check this :)                          |
+| `inserted_at` | `string` | see above...                                                |
+
+#### Errors
+
+TODO: describe possible error types, how to distinguish between them
 
 ### `account/recover`
 
@@ -31,3 +54,12 @@ TODO: clarify that delegations with caveats act as constraints (see https://www.
 
 ## Storage service
 
+### `store/add`
+
+### `store/remove`
+
+### `store/list`
+
+## Uploads service
+
+TODO


### PR DESCRIPTION
This is a start at a reference doc for all the capabilities defined in this repo. 

There's also a stub for a "services.md" that will have details about the response values and possible error types for each capability handler.

So far, I've got `store/add` and `store/remove` covered, plus some intro context material.

@alanshaw, could you give some early 👀 to make sure the format works for you, and that you have all the info here that you would expect?

closes #172