### PR TITLE
fix: store add capabilities

### DIFF
--- a/packages/access/src/capabilities/store.js
+++ b/packages/access/src/capabilities/store.js
@@ -31,7 +31,7 @@ export const add = base.derive({
     can: 'store/add',
     with: URI.match({ protocol: 'did:' }),
     nb: {
-      link: Link.optional(),
+      link: Link.link(),
       origin: Link.optional(),
       size: Schema.integer().optional(),
     },

--- a/packages/access/test/capabilities/store.test.js
+++ b/packages/access/test/capabilities/store.test.js
@@ -155,6 +155,7 @@ describe('store capabilities', function () {
         audience: bob,
         with: account.did(),
         nb: {
+          link: parseLink('bafkqaaa'),
           size: 1024,
         },
         proofs: [await any],
@@ -223,12 +224,14 @@ describe('store capabilities', function () {
     const json = JSON.stringify(size)
     it(`store/add size must be an int not ${json}`, async () => {
       const proofs = [await any]
+      const link = await createCarCid('bafkqaaa')
       assert.throws(() => {
         Store.add.invoke({
           issuer: alice,
           audience: w3,
           with: account.did(),
           nb: {
+            link,
             // @ts-expect-error
             size,
           },
@@ -276,6 +279,7 @@ describe('store capabilities', function () {
         audience: w3,
         with: account.did(),
         nb: {
+          link: parseLink('bafkqaaa'),
           size: 1024.2,
         },
         proofs,


### PR DESCRIPTION
`store/add` invocation should have at bare minimum link required.

However, perhaps we should make size required given we want to use it for the signed url?

BREAKING CHANGE: store/add capabilities now have required properties
