### PR TITLE
fix: workaround for ts bug in upload capabilities

### DIFF
--- a/packages/access/src/capabilities/upload.js
+++ b/packages/access/src/capabilities/upload.js
@@ -137,3 +137,7 @@ export const list = base.derive({
    */
   derives: equalWith,
 })
+
+// ⚠️ We export imports here so they are not omited in generated typedes
+// @see https://github.com/microsoft/TypeScript/issues/51548
+export { Link }

--- a/packages/access/src/capabilities/upload.js
+++ b/packages/access/src/capabilities/upload.js
@@ -138,6 +138,6 @@ export const list = base.derive({
   derives: equalWith,
 })
 
-// ⚠️ We export imports here so they are not omited in generated typedes
+// ⚠️ We export imports here so they are not omited in generated typedefs
 // @see https://github.com/microsoft/TypeScript/issues/51548
 export { Link }


### PR DESCRIPTION
Same as https://github.com/web3-storage/w3protocol/pull/169 but for upload capabilities. Did also a quick look at generated types in other capabilities and they look fine.