### PR TITLE
feat: add support for list pagination in list capability invocations

### DIFF
--- a/packages/access-client/src/capabilities/store.js
+++ b/packages/access-client/src/capabilities/store.js
@@ -140,6 +140,18 @@ export const list = base.derive({
      * be stored.
      */
     with: URI.match({ protocol: 'did:' }),
+    nb: {
+      /**
+       * Item where a previous list operation stopped, inclusive of the previous
+       * result set. Use this value to start a new operation, inorder to paginate
+       * list.
+       */
+      cursor: Schema.string().optional(),
+      /**
+       * Size of the page being requested to list.
+       */
+      size: Schema.integer().optional(),
+    },
     derives: (claimed, delegated) => {
       if (claimed.with !== delegated.with) {
         return new Failure(

--- a/packages/access-client/src/capabilities/store.js
+++ b/packages/access-client/src/capabilities/store.js
@@ -143,12 +143,12 @@ export const list = base.derive({
     nb: {
       /**
        * Item where a previous list operation stopped, inclusive of the previous
-       * result set. Use this value to start a new operation, inorder to paginate
+       * result set. Use this value to start a new operation, in order to paginate
        * list.
        */
       cursor: Schema.string().optional(),
       /**
-       * Size of the page being requested to list.
+       * Maximum number of items per page.
        */
       size: Schema.integer().optional(),
     },

--- a/packages/access-client/src/capabilities/store.js
+++ b/packages/access-client/src/capabilities/store.js
@@ -142,9 +142,8 @@ export const list = base.derive({
     with: URI.match({ protocol: 'did:' }),
     nb: {
       /**
-       * Item where a previous list operation stopped, inclusive of the previous
-       * result set. Use this value to start a new operation, in order to paginate
-       * list.
+       * A pointer that can be moved back and forth on the list.
+       * It can be used to paginate a list for instance.
        */
       cursor: Schema.string().optional(),
       /**

--- a/packages/access-client/src/capabilities/upload.js
+++ b/packages/access-client/src/capabilities/upload.js
@@ -8,7 +8,7 @@
  *
  * @module
  */
-import { capability, Link, URI } from '@ucanto/validator'
+ import { capability, Link, URI, Schema } from '@ucanto/validator'
 import { codec as CAR } from '@ucanto/transport/car'
 import { equalWith, fail, equal } from './utils.js'
 import { top } from './top.js'
@@ -140,6 +140,18 @@ export const list = base.derive({
   to: capability({
     can: 'upload/list',
     with: URI.match({ protocol: 'did:' }),
+    nb: {
+      /**
+       * Item where a previous list operation stopped, inclusive of the previous
+       * result set. Use this value to start a new operation, inorder to paginate
+       * list.
+       */
+      cursor: Schema.string().optional(),
+      /**
+       * Size of the page being requested to list.
+       */
+      size: Schema.integer().optional(),
+    },
   }),
   /**
    * `upload/list` can be derived from the `upload/*` & `*` capability
@@ -150,4 +162,4 @@ export const list = base.derive({
 
 // ⚠️ We export imports here so they are not omited in generated typedefs
 // @see https://github.com/microsoft/TypeScript/issues/51548
-export { Link }
+export { Link, Schema }

--- a/packages/access-client/src/capabilities/upload.js
+++ b/packages/access-client/src/capabilities/upload.js
@@ -143,12 +143,12 @@ export const list = base.derive({
     nb: {
       /**
        * Item where a previous list operation stopped, inclusive of the previous
-       * result set. Use this value to start a new operation, inorder to paginate
+       * result set. Use this value to start a new operation, in order to paginate
        * list.
        */
       cursor: Schema.string().optional(),
       /**
-       * Size of the page being requested to list.
+       * Maximum number of items per page.
        */
       size: Schema.integer().optional(),
     },

--- a/packages/access-client/src/capabilities/upload.js
+++ b/packages/access-client/src/capabilities/upload.js
@@ -8,7 +8,7 @@
  *
  * @module
  */
- import { capability, Link, URI, Schema } from '@ucanto/validator'
+import { capability, Link, URI, Schema } from '@ucanto/validator'
 import { codec as CAR } from '@ucanto/transport/car'
 import { equalWith, fail, equal } from './utils.js'
 import { top } from './top.js'
@@ -142,9 +142,8 @@ export const list = base.derive({
     with: URI.match({ protocol: 'did:' }),
     nb: {
       /**
-       * Item where a previous list operation stopped, inclusive of the previous
-       * result set. Use this value to start a new operation, in order to paginate
-       * list.
+       * A pointer that can be moved back and forth on the list.
+       * It can be used to paginate a list for instance.
        */
       cursor: Schema.string().optional(),
       /**

--- a/packages/access-client/test/capabilities/upload.test.js
+++ b/packages/access-client/test/capabilities/upload.test.js
@@ -328,6 +328,7 @@ describe('upload capabilities', function () {
       audience: w3,
       with: account.did(),
       proofs: [await any],
+      nb: {},
     })
 
     const result = await access(await list.delegate(), {
@@ -357,6 +358,7 @@ describe('upload capabilities', function () {
       issuer: bob,
       with: account.did(),
       proofs: [await upload.delegate()],
+      nb: {},
     })
 
     const result = await access(await list.delegate(), {
@@ -379,6 +381,7 @@ describe('upload capabilities', function () {
       audience: bob,
       with: account.did(),
       proofs: [await any],
+      nb: {},
     })
 
     const list = Upload.list.invoke({
@@ -386,6 +389,7 @@ describe('upload capabilities', function () {
       issuer: bob,
       with: account.did(),
       proofs: [await delegation.delegate()],
+      nb: {},
     })
 
     const result = await access(await list.delegate(), {


### PR DESCRIPTION
Adds support for list pagination in `store/list` and `upload/list`.

Relevant notes on decisions made:
- unfortunately, Databases like DynamoDB does not support pagination by just giving `pageNumber` and `size`. Aiming to have something generic (that works in DynamoDB, but also other DBs), chosen approach is to rely on `cursor` and `size` .
- at first, attempted to make `cursor` a Link property of the capability. And it worked well for `store/list`, but then I got to use cases (`upload/list` for instance) where it cannot be a link. This is because Upload Table primary key contains `${dataCid}#${carCid}` to be unique. So, in this case that is the cursor we need to have. There might be other kind of use cases, so having this as string is really the most flexible approach to support pagination.

Note:
- it would be great to get a fix for https://github.com/web3-storage/ucanto/issues/140 before merging this

BREAKING CHANGE: store/list and upload/list types now require nb object with optional properties