### PR TITLE
fix: store export

### DIFF
--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -35,7 +35,7 @@ const agent = await Agent.create()
 const conf = {
   issuer: agent.issuer,
   with: agent.currentSpace(),
-  proofs: agent.getProofs([store, upload]),
+  proofs: await agent.proofs([store, upload]),
 }
 ```
 

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -1,10 +1,10 @@
-import * as Storage from './store.js'
+import * as Store from './store.js'
 import * as Upload from './upload.js'
 import * as UnixFS from './unixfs.js'
 import * as CAR from './car.js'
 import { ShardingStream, ShardStoringStream } from './sharding.js'
 
-export { Storage, Upload, UnixFS, CAR }
+export { Store, Upload, UnixFS, CAR }
 export * from './sharding.js'
 
 /**


### PR DESCRIPTION
Documented as `Store` in the README and this it aligns better with the capability name. I had it as `Storage` for a while but changed it to `Store`...but missed this instance 🤦‍♂️