### PR TITLE
fix: list response results return type

### DIFF
--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -49,7 +49,7 @@ export interface StoreAddResponse {
 export interface ListResponse<R> {
   cursor?: string
   size: number
-  results?: R[]
+  results: R[]
 }
 
 export interface StoreListResult {


### PR DESCRIPTION
It now always returns an array.