### PR TITLE
fix: do not load conf in browser

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -32,6 +32,9 @@
     "./types": "./src/types.js",
     "./encoding": "./src/encoding.js"
   },
+  "browser": {
+    "./src/stores/store-conf.js": false
+  },
   "typesVersions": {
     "*": {
       "types": [


### PR DESCRIPTION
Rollup unfortunately does not seem to be able to tree shake this module.