### PR TITLE
feat!: rename static indexeddb store method create to open

### DIFF
--- a/packages/access-client/src/stores/store-indexeddb.js
+++ b/packages/access-client/src/stores/store-indexeddb.js
@@ -110,7 +110,10 @@ export class StoreIndexedDB {
   static async create(dbName, options) {
     const store = new StoreIndexedDB(dbName, options)
     await store.open()
-    await store.init({})
+    const exists = await store.exists()
+    if (!exists) {
+      await store.init({})
+    }
     return store
   }
 

--- a/packages/access-client/src/stores/store-indexeddb.js
+++ b/packages/access-client/src/stores/store-indexeddb.js
@@ -99,7 +99,7 @@ export class StoreIndexedDB {
   }
 
   /**
-   * Creates a new, opened and initialized store.
+   * Opens (or creates) a store and initializes it if not already initialized.
    *
    * @param {string} dbName
    * @param {object} [options]
@@ -107,7 +107,7 @@ export class StoreIndexedDB {
    * @param {string} [options.dbStoreName]
    * @returns {Promise<Store>}
    */
-  static async create(dbName, options) {
+  static async open(dbName, options) {
     const store = new StoreIndexedDB(dbName, options)
     await store.open()
     const exists = await store.exists()

--- a/packages/access-client/test/stores/store-indexeddb.browser.test.js
+++ b/packages/access-client/test/stores/store-indexeddb.browser.test.js
@@ -3,7 +3,7 @@ import { StoreIndexedDB } from '../../src/stores/store-indexeddb.js'
 
 describe('IndexedDB store', () => {
   it('should create and load data', async () => {
-    const store = await StoreIndexedDB.create('test-access-db-' + Date.now())
+    const store = await StoreIndexedDB.open('test-access-db-' + Date.now())
     const data = await store.load()
     assert(data)
 
@@ -23,7 +23,7 @@ describe('IndexedDB store', () => {
   })
 
   it('should allow custom store name', async () => {
-    const store = await StoreIndexedDB.create('test-access-db-' + Date.now(), {
+    const store = await StoreIndexedDB.open('test-access-db-' + Date.now(), {
       dbStoreName: `store-${Date.now()}`,
     })
     const data = await store.load()
@@ -44,7 +44,7 @@ describe('IndexedDB store', () => {
   })
 
   it('should close and disallow usage', async () => {
-    const store = await StoreIndexedDB.create('test-access-db-' + Date.now())
+    const store = await StoreIndexedDB.open('test-access-db-' + Date.now())
     const data = await store.load()
 
     await store.close()


### PR DESCRIPTION
This `create` function is kinda useless except for in tests right now because as soon as you use it for the second time it blows away the existing data.