### PR TITLE
fix: round trip delegations in IndexedDB store

### DIFF
--- a/packages/access-client/src/stores/store-indexeddb.js
+++ b/packages/access-client/src/stores/store-indexeddb.js
@@ -154,7 +154,7 @@ export class StoreIndexedDB {
         const raw = {
           id: DATA_ID,
           meta: data.meta,
-          // @ts-ignore
+          // @ts-expect-error
           principal: data.principal.toArchive(),
           currentSpace: data.currentSpace,
           spaces: data.spaces,

--- a/packages/access-client/src/stores/types.ts
+++ b/packages/access-client/src/stores/types.ts
@@ -6,7 +6,7 @@ import {
   SpaceMeta,
 } from '../types.js'
 import { RSASigner } from '@ucanto/principal/rsa'
-import { SignerArchive, DID, Block } from '@ucanto/interface'
+import { SignerArchive, DID } from '@ucanto/interface'
 
 /**
  * Store interface that all stores need to implement
@@ -57,7 +57,7 @@ export interface StoreDataIDB {
     CIDString,
     {
       meta?: DelegationMeta
-      delegation: Block[]
+      delegation: Array<{ cid: CIDString; bytes: Uint8Array }>
     }
   >
 }


### PR DESCRIPTION
You can't store a CID instance in IndexedDB.