### PR TITLE
add packages/capabilities to .github/release-please-manifest.json

### DIFF
--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -2,5 +2,6 @@
   "packages/wallet": "1.0.0",
   "packages/access-client": "7.0.2",
   "packages/access-api": "3.0.0",
+  "packages/capabilities": "0.0.0",
   "packages/upload-client": "2.1.0"
 }


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/80#issuecomment-1331443102
* trying to get release-please-action to generate a release PR for packages/capabilities
* I would have expected it in this action, but there was [an error](https://github.com/web3-storage/w3protocol/actions/runs/3587365143/jobs/6037622712#step:2:44)
```
Expected 5 releases, only found 4
⚠ Missing 1 paths: packages/capabilities
⚠ No version for path packages/capabilities
```

Theory:
* maybe these errors are because I hadn't added this package to the manifest?