### PR TITLE
fix: remove remaining references to packages/wallet

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,7 +4,6 @@
     "packages/access-client": {},
     "packages/access-api": {},
     "packages/capabilities": {},
-    "packages/upload-client": {},
-    "packages/wallet": {}
+    "packages/upload-client": {}
   }
 }

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,5 +1,4 @@
 {
-  "packages/wallet": "1.0.0",
   "packages/access-client": "7.0.2",
   "packages/access-api": "3.0.0",
   "packages/capabilities": "1.0.0",

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -11,7 +11,6 @@ on:
           - access-api
           - upload-client
           - access-client
-          - wallet
           - docs
       environment:
         description: 'Environment to deploy'
@@ -23,30 +22,6 @@ on:
           - staging
           - dev
 jobs:
-  deploy-wallet:
-    runs-on: ubuntu-latest
-    if: github.event.inputs.package == 'wallet'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.3
-        with:
-          version: 7
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'pnpm'
-      - uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/packages/wallet/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('packages/wallet/**.[jt]s', 'packages/wallet/**.[jt]sx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-      - run: pnpm install
-      - run: pnpm -r --filter wallet run build
-      - run: pnpm exec wrangler pages publish --project-name ucan-protocol --branch main ./packages/wallet/out
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
   deploy-access-api:
     if: github.event.inputs.package == 'access-api'
     uses: './.github/workflows/reusable-deploy-api.yml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,6 @@ jobs:
           manifest-file: .github/release-please-manifest.json
           default-branch: main
           release-type: node
-  pages:
-    needs: release
-    if: contains(fromJson(needs.release.outputs.paths_released), 'packages/wallet')
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo 'pages'
   access-api:
     needs: release
     if: contains(fromJson(needs.release.outputs.paths_released), 'packages/access-api')


### PR DESCRIPTION
Motivation:
* latest commit on main branch was failing release workflow [here](https://github.com/web3-storage/w3protocol/actions/runs/3621669639/jobs/6105393187#step:2:35)
  * I think it's because the release-please config/manifest still referred to `package/wallet`, which this PR removes
  * seems like logical followup to https://github.com/web3-storage/w3protocol/pull/248