### PR TITLE
refactor: sync delegations method

### DIFF
--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -194,9 +194,15 @@ export class Agent {
    * @param {import('@ucanto/interface').Capability[]} [caps] - Capabilities to filter by. Empty or undefined caps with return all the proofs.
    */
   proofs(caps) {
-    return this.#delegations(caps)
-      .filter((v) => v.delegation.audience.did() === this.issuer.did())
-      .map((v) => v.delegation)
+    const arr = []
+
+    for (const value of this.#delegations(caps)) {
+      if (value.delegation.audience.did() === this.issuer.did()) {
+        arr.push(value.delegation)
+      }
+    }
+
+    return arr
   }
 
   /**
@@ -205,7 +211,13 @@ export class Agent {
    * @param {import('@ucanto/interface').Capability[]} [caps] - Capabilities to filter by. Empty or undefined caps with return all the delegations.
    */
   delegations(caps) {
-    return this.delegationsWithMeta(caps).map((v) => v.delegation)
+    const arr = []
+
+    for (const { delegation } of this.delegationsWithMeta(caps)) {
+      arr.push(delegation)
+    }
+
+    return arr
   }
 
   /**
@@ -214,9 +226,15 @@ export class Agent {
    * @param {import('@ucanto/interface').Capability[]} [caps] - Capabilities to filter by. Empty or undefined caps with return all the delegations.
    */
   delegationsWithMeta(caps) {
-    return this.#delegations(caps).filter(
-      (v) => v.delegation.audience.did() !== this.issuer.did()
-    )
+    const arr = []
+
+    for (const value of this.#delegations(caps)) {
+      if (value.delegation.audience.did() !== this.issuer.did()) {
+        arr.push(value)
+      }
+    }
+
+    return arr
   }
 
   /**

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -155,20 +155,22 @@ export class Agent {
     const values = []
     for (const [, value] of this.#data.delegations) {
       // check expiration
-      if (!isExpired(value.delegation) && // check if delegation can be used
-        !isTooEarly(value.delegation)) {
-          // check if we need to filter for caps
-          if (Array.isArray(caps) && caps.length > 0) {
-            for (const cap of _caps) {
-              if (canDelegateCapability(value.delegation, cap)) {
-                _caps.delete(cap)
-                values.push(value)
-              }
+      if (
+        !isExpired(value.delegation) && // check if delegation can be used
+        !isTooEarly(value.delegation)
+      ) {
+        // check if we need to filter for caps
+        if (Array.isArray(caps) && caps.length > 0) {
+          for (const cap of _caps) {
+            if (canDelegateCapability(value.delegation, cap)) {
+              _caps.delete(cap)
+              values.push(value)
             }
-          } else {
-            values.push(value)
           }
+        } else {
+          values.push(value)
         }
+      }
     }
     return values
   }

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -142,6 +142,7 @@ export class Agent {
       checkIsExpired: true,
     })
     await this.#data.addDelegation(delegation, { audience: this.meta })
+    await this.removeExpiredDelegations()
   }
 
   /**
@@ -537,6 +538,7 @@ export class Agent {
     await this.#data.addDelegation(delegation, {
       audience: options.audienceMeta,
     })
+    await this.removeExpiredDelegations()
 
     return delegation
   }

--- a/packages/access-client/src/cli/cmd-whoami.js
+++ b/packages/access-client/src/cli/cmd-whoami.js
@@ -13,7 +13,7 @@ export async function cmdWhoami(opts) {
   if (data) {
     const agent = Agent.from(data, { store })
     console.log('Agent', agent.issuer.did(), agent.meta)
-    console.log('Current Space', await agent.currentSpaceWithMeta())
+    console.log('Current Space', agent.currentSpaceWithMeta())
     console.log('\nSpaces:')
     for (const space of agent.spaces) {
       console.log(
@@ -23,7 +23,7 @@ export async function cmdWhoami(opts) {
       )
     }
     console.log('\nProofs:')
-    for (const proof of await agent.proofs()) {
+    for (const proof of agent.proofs()) {
       for (const cap of proof.capabilities) {
         console.log(
           `With resource: ${cap.with} can "${cap.can}" expires at ${proof.expiration}`
@@ -32,7 +32,7 @@ export async function cmdWhoami(opts) {
     }
 
     console.log('\nDelegations:')
-    for await (const { meta, delegation } of agent.delegationsWithMeta()) {
+    for (const { meta, delegation } of agent.delegationsWithMeta()) {
       console.log(
         `Audience ${meta.audience?.name ?? 'unknown'} (${
           meta.audience?.type ?? 'unknown'

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -23,7 +23,7 @@ describe('Agent', function () {
   it('should add proof when creating acccount', async function () {
     const agent = await Agent.create()
     const space = await agent.createSpace('test-add')
-    const delegations = await agent.proofs()
+    const delegations = agent.proofs()
 
     assert.equal(space.proof.cid, delegations[0].cid)
   })


### PR DESCRIPTION
By removing the side effect many methods that read data in memory no longer have to be async. I think this makes the API simplier.

I've added a _method_ that can be called to clean up expired delegations, which shifts the responsibility onto the user. Alternatively we could move the clean up into the methods that write delegations? Open to other suggestions.

resolves #219