### PR TITLE
chore: run `pnpm run build` before typedoc to avoid type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm -r --if-present run test",
     "check": "pnpm -r --if-present run check",
     "build": "pnpm -r --if-present run build",
-    "docs": "typedoc --out docs"
+    "docs": "pnpm run build && typedoc --out docs"
   },
   "devDependencies": {
     "lint-staged": "^13.0.4",


### PR DESCRIPTION
I noticed earlier today that running `pnpm run docs` fails with a bunch of typescript errors unless you run `pnpm run build` first.

This just updates the `docs` npm script to `pnpm run build && typedoc --out docs`, so we'll always have build output to make typedoc happy.

<details>
<summary>error output if you don't build first</summary>

```
packages/access-client/src/agent.js:12:24 - error TS2307: Cannot find module '@web3-storage/capabilities/space' or its corresponding type declarations.

12 import * as Space from '@web3-storage/capabilities/space'
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

packages/access-client/src/agent.js:13:26 - error TS2307: Cannot find module '@web3-storage/capabilities/voucher' or its corresponding type declarations.

13 import * as Voucher from '@web3-storage/capabilities/voucher'
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

packages/access-client/src/agent.js:260:65 - error TS2694: Namespace '"/home/yusef/work/repos/w3protocol/packages/access-client/src/types"' has no exported member 'Top'.

260     const del = /** @type {Ucanto.Delegation<[import('./types').Top]>} */ (
                                                                    ~~~

packages/access-client/src/agent.js:286:7 - error TS2322: Type '{ identity: Client.URI<"mailto:">; }' is not assignable to type 'undefined'.

286       nb: { identity: URI.from(`mailto:${email}`) },
          ~~
```

many more lines omitted...
</details>