### PR TITLE
fix: destructured save

### DIFF
--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -20,7 +20,8 @@ export class AgentData {
     this.spaces = data.spaces
     this.delegations = data.delegations
     this.currentSpace = data.currentSpace
-    this.#save = options.store ? options.store.save : () => {}
+    this.#save = (data) =>
+      options.store ? options.store.save(data) : undefined
   }
 
   /**

--- a/packages/access-client/test/agent-data.test.js
+++ b/packages/access-client/test/agent-data.test.js
@@ -3,11 +3,13 @@ import { AgentData } from '../src/agent-data.js'
 
 describe('AgentData', () => {
   it('should not destructure store methods', async () => {
+    // eslint-disable-next-line unicorn/no-await-expression-member
+    const raw = (await AgentData.create()).export()
     class Store {
       async open() {}
       async close() {}
       async load() {
-        
+        return raw
       }
 
       async reset() {}

--- a/packages/access-client/test/agent-data.test.js
+++ b/packages/access-client/test/agent-data.test.js
@@ -1,0 +1,24 @@
+import assert from 'assert'
+import { AgentData } from '../src/agent-data.js'
+
+describe('AgentData', () => {
+  it('should not destructure store methods', async () => {
+    class Store {
+      async open() {}
+      async close() {}
+      async load() {
+        
+      }
+
+      async reset() {}
+      async save() {
+        if (!(this instanceof Store)) {
+          throw new TypeError('unexpected this value')
+        }
+      }
+    }
+    const store = new Store()
+    const data = await AgentData.create(undefined, { store })
+    await assert.doesNotReject(data.setCurrentSpace('did:x:y'))
+  })
+})


### PR DESCRIPTION
Destructuring the `save` method of the passed store is causing problems when the store wants to access instance vars/methods.