### PR TITLE
feat: access-api uses DID env variable when building its ucanto server id

### DIFF
--- a/packages/access-api/package.json
+++ b/packages/access-api/package.json
@@ -22,6 +22,7 @@
     "@ucanto/principal": "^4.0.2",
     "@ucanto/server": "^4.0.2",
     "@ucanto/transport": "^4.0.2",
+    "@ucanto/validator": "^4.0.2",
     "@web3-storage/access": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/worker-utils": "0.4.3-dev",

--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -23,6 +23,11 @@ export interface Env {
   // vars
   ENV: string
   DEBUG: string
+  /**
+   * publicly advertised decentralized identifier of the running api service
+   * * this may be used to filter incoming ucanto invocations
+   */
+  DID: string
   // secrets
   PRIVATE_KEY: string
   SENTRY_DSN: string

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -32,11 +32,14 @@ export function loadConfig(env) {
     }
   }
 
+  const DID = env.DID
+  const PRIVATE_KEY = vars.PRIVATE_KEY
+  const signer = configureSigner({ DID, PRIVATE_KEY })
   return {
     DEBUG: boolValue(vars.DEBUG),
     ENV: parseRuntimeEnv(vars.ENV),
 
-    PRIVATE_KEY: vars.PRIVATE_KEY,
+    PRIVATE_KEY,
     POSTMARK_TOKEN: vars.POSTMARK_TOKEN,
     SENTRY_DSN: vars.SENTRY_DSN,
     LOGTAIL_TOKEN: vars.LOGTAIL_TOKEN,
@@ -52,7 +55,8 @@ export function loadConfig(env) {
     // eslint-disable-next-line no-undef
     COMMITHASH: ACCOUNT_COMMITHASH,
 
-    DID: env.DID,
+    DID,
+    signer,
 
     // bindings
     METRICS:

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -39,7 +39,6 @@ export function loadConfig(env) {
     DEBUG: boolValue(vars.DEBUG),
     ENV: parseRuntimeEnv(vars.ENV),
 
-    PRIVATE_KEY,
     POSTMARK_TOKEN: vars.POSTMARK_TOKEN,
     SENTRY_DSN: vars.SENTRY_DSN,
     LOGTAIL_TOKEN: vars.LOGTAIL_TOKEN,
@@ -55,7 +54,6 @@ export function loadConfig(env) {
     // eslint-disable-next-line no-undef
     COMMITHASH: ACCOUNT_COMMITHASH,
 
-    DID,
     signer,
 
     // bindings

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -1,3 +1,4 @@
+import { DID } from '@ucanto/validator'
 import { Signer } from '@ucanto/principal/ed25519'
 
 /**
@@ -119,13 +120,14 @@ export function createAnalyticsEngine() {
  */
 export function configureSigner(config) {
   const signer = Signer.parse(config.PRIVATE_KEY)
-  if (config.DID) {
-    if (!isDID(config.DID)) {
-      throw new Error(`Invalid DID: ${config.DID}`)
-    }
-    return signer.withDID(config.DID)
+  const did = config.DID
+  if (!did) {
+    return signer
   }
-  return signer
+  if (!isDID(did)) {
+    throw new Error(`Invalid DID: ${did}`)
+  }
+  return signer.withDID(did)
 }
 
 /**
@@ -136,9 +138,8 @@ export function configureSigner(config) {
  * @returns {object is `did:${string}:${string}`}
  */
 function isDID(object) {
-  if (typeof object !== 'string') return false
-  const parts = object.split(':')
-  if (parts.length <= 2) return false
-  if (parts[0] !== 'did') return false
-  return true
+  try {
+    return Boolean(DID.match({}).from(object))
+  } catch {}
+  return false
 }

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -128,22 +128,5 @@ export function configureSigner(config) {
   if (!did) {
     return signer
   }
-  if (!isDID(did)) {
-    throw new Error(`Invalid DID: ${did}`)
-  }
-  return signer.withDID(did)
-}
-
-/**
- * Return whether or not the provided object looks like a decentralized identifier (aka DID)
- *
- * @see https://www.w3.org/TR/did-core/#did-syntax
- * @param {any} object
- * @returns {object is `did:${string}:${string}`}
- */
-function isDID(object) {
-  try {
-    return Boolean(DID.match({}).from(object))
-  } catch {}
-  return false
+  return signer.withDID(DID.match({}).from(did))
 }

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -1,7 +1,7 @@
 import { Logging } from '@web3-storage/worker-utils/logging'
 import Toucan from 'toucan-js'
 import pkg from '../../package.json'
-import { configureSigner, loadConfig } from '../config.js'
+import { loadConfig } from '../config.js'
 import { Spaces } from '../kvs/spaces.js'
 import { Validations } from '../kvs/validations.js'
 import { Email } from './email.js'
@@ -40,13 +40,11 @@ export function getContext(request, env, ctx) {
     commit: config.COMMITHASH,
     env: config.ENV,
   })
-
-  const signer = configureSigner(config)
   const url = new URL(request.url)
   const db = new D1QB(config.DB)
   return {
     log,
-    signer,
+    signer: config.signer,
     config,
     url,
     kvs: {

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -1,8 +1,7 @@
-import { Signer } from '@ucanto/principal/ed25519'
 import { Logging } from '@web3-storage/worker-utils/logging'
 import Toucan from 'toucan-js'
 import pkg from '../../package.json'
-import { loadConfig } from '../config.js'
+import { configureSigner, loadConfig } from '../config.js'
 import { Spaces } from '../kvs/spaces.js'
 import { Validations } from '../kvs/validations.js'
 import { Email } from './email.js'
@@ -42,12 +41,12 @@ export function getContext(request, env, ctx) {
     env: config.ENV,
   })
 
-  const keypair = Signer.parse(config.PRIVATE_KEY)
+  const signer = configureSigner(config)
   const url = new URL(request.url)
   const db = new D1QB(config.DB)
   return {
     log,
-    signer: keypair,
+    signer,
     config,
     url,
     kvs: {

--- a/packages/access-api/test/config.test.js
+++ b/packages/access-api/test/config.test.js
@@ -1,28 +1,47 @@
 import assert from 'assert'
 import * as configModule from '../src/config.js'
 
+/** keypair that can be used for testing */
+const testKeypair = {
+  private: {
+    /**
+     * Private key encoded as multiformats
+     */
+    multiformats:
+      'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
+  },
+  public: {
+    /**
+     * Public key encoded as a did:key
+     */
+    did: 'did:key:z6MkqBzPG7oNu7At8fktasQuS7QR7Tj7CujaijPMAgzdmAxD',
+  },
+}
+
 describe('@web3-storage/access-api/src/config configureSigner', () => {
-  it('configureSigner creates a signer using config.{DID,PRIVATE_KEY}', async () => {
+  it('creates a signer using config.{DID,PRIVATE_KEY}', async () => {
     const config = {
-      PRIVATE_KEY:
-        'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
-      DID: 'did:web:example.com',
+      PRIVATE_KEY: testKeypair.private.multiformats,
+      DID: testKeypair.public.did,
     }
     const signer = configModule.configureSigner(config)
     assert.ok(signer)
     assert.equal(signer.did().toString(), config.DID)
   })
-  it('configureSigner infers did from config.PRIVATE_KEY when config.DID is omitted', async () => {
-    const testKey = {
-      PRIVATE_KEY:
-        'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
-      didKey: 'did:key:z6MkqBzPG7oNu7At8fktasQuS7QR7Tj7CujaijPMAgzdmAxD',
-    }
+  it('errors if config.DID is provided but not a did', () => {
+    assert.throws(() => {
+      configModule.configureSigner({
+        DID: 'not a did',
+        PRIVATE_KEY: testKeypair.private.multiformats,
+      })
+    }, 'Invalid DID')
+  })
+  it('infers did from config.PRIVATE_KEY when config.DID is omitted', async () => {
     const config = {
-      PRIVATE_KEY: testKey.PRIVATE_KEY,
+      PRIVATE_KEY: testKeypair.private.multiformats,
     }
     const signer = configModule.configureSigner(config)
     assert.ok(signer)
-    assert.equal(signer.did().toString(), testKey.didKey)
+    assert.equal(signer.did().toString(), testKeypair.public.did)
   })
 })

--- a/packages/access-api/test/config.test.js
+++ b/packages/access-api/test/config.test.js
@@ -1,0 +1,28 @@
+import assert from 'assert'
+import * as configModule from '../src/config.js'
+
+describe('@web3-storage/access-api/src/config configureSigner', () => {
+  it('configureSigner creates a signer using config.{DID,PRIVATE_KEY}', async () => {
+    const config = {
+      PRIVATE_KEY:
+        'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
+      DID: 'did:web:example.com',
+    }
+    const signer = configModule.configureSigner(config)
+    assert.ok(signer)
+    assert.equal(signer.did().toString(), config.DID)
+  })
+  it('configureSigner infers did from config.PRIVATE_KEY when config.DID is omitted', async () => {
+    const testKey = {
+      PRIVATE_KEY:
+        'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
+      didKey: 'did:key:z6MkqBzPG7oNu7At8fktasQuS7QR7Tj7CujaijPMAgzdmAxD',
+    }
+    const config = {
+      PRIVATE_KEY: testKey.PRIVATE_KEY,
+    }
+    const signer = configModule.configureSigner(config)
+    assert.ok(signer)
+    assert.equal(signer.did().toString(), testKey.didKey)
+  })
+})

--- a/packages/access-api/test/config.test.js
+++ b/packages/access-api/test/config.test.js
@@ -22,11 +22,14 @@ describe('@web3-storage/access-api/src/config configureSigner', () => {
   it('creates a signer using config.{DID,PRIVATE_KEY}', async () => {
     const config = {
       PRIVATE_KEY: testKeypair.private.multiformats,
-      DID: testKeypair.public.did,
+      DID: 'did:web:exampe.com',
     }
     const signer = configModule.configureSigner(config)
     assert.ok(signer)
     assert.equal(signer.did().toString(), config.DID)
+    const { keys } = signer.toArchive()
+    const didKeys = Object.keys(keys)
+    assert.deepEqual(didKeys, [testKeypair.public.did])
   })
   it('errors if config.DID is provided but not a did', () => {
     assert.throws(() => {

--- a/packages/access-api/test/ucan.test.js
+++ b/packages/access-api/test/ucan.test.js
@@ -144,6 +144,31 @@ describe('ucan', function () {
     t.deepEqual(rsp, ['test pass'])
   })
 
+  test('should support ucan invoking to a did:web aud', async function () {
+    const serviceDidWeb = 'did:web:web3.storage'
+    const { mf, issuer, service } = await context({
+      environment: {
+        ...process.env,
+        PRIVATE_KEY:
+          'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
+        DID: serviceDidWeb,
+      },
+    })
+    const ucan = await UCAN.issue({
+      issuer,
+      audience: service.withDID('did:web:web3.storage'),
+      capabilities: [{ can: 'testing/pass', with: 'mailto:admin@dag.house' }],
+    })
+    const res = await mf.dispatchFetch('http://localhost:8787/raw', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${UCAN.format(ucan)}`,
+      },
+    })
+    const rsp = await res.json()
+    t.deepEqual(rsp, ['test pass'])
+  })
+
   test('should handle exception in route handler', async function () {
     const { mf, service, issuer } = ctx
 

--- a/packages/access-api/test/ucan.test.js
+++ b/packages/access-api/test/ucan.test.js
@@ -145,18 +145,16 @@ describe('ucan', function () {
   })
 
   test('should support ucan invoking to a did:web aud', async function () {
-    const serviceDidWeb = 'did:web:web3.storage'
+    const serviceDidWeb = 'did:web:example.com'
     const { mf, issuer, service } = await context({
       environment: {
         ...process.env,
-        PRIVATE_KEY:
-          'MgCYWjE6vp0cn3amPan2xPO+f6EZ3I+KwuN1w2vx57vpJ9O0Bn4ci4jn8itwc121ujm7lDHkCW24LuKfZwIdmsifVysY=',
         DID: serviceDidWeb,
       },
     })
     const ucan = await UCAN.issue({
       issuer,
-      audience: service.withDID('did:web:web3.storage'),
+      audience: service.withDID(serviceDidWeb),
       capabilities: [{ can: 'testing/pass', with: 'mailto:admin@dag.house' }],
     })
     const res = await mf.dispatchFetch('http://localhost:8787/raw', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ importers:
       '@ucanto/principal': ^4.0.2
       '@ucanto/server': ^4.0.2
       '@ucanto/transport': ^4.0.2
+      '@ucanto/validator': ^4.0.2
       '@web3-storage/access': workspace:^
       '@web3-storage/capabilities': workspace:^
       '@web3-storage/worker-utils': 0.4.3-dev
@@ -71,6 +72,7 @@ importers:
       '@ucanto/principal': 4.0.2
       '@ucanto/server': 4.0.2
       '@ucanto/transport': 4.0.2
+      '@ucanto/validator': 4.0.2
       '@web3-storage/access': link:../access-client
       '@web3-storage/capabilities': link:../capabilities
       '@web3-storage/worker-utils': 0.4.3-dev


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/237

Notes
* This is intended to be safe to merge/deploy as is. The new functionality can be opted-into via env vars
* The ucanto server will only be constructed with an opts.id that is a signer `withDID(...)` iff `process.env.DID` is set to a DID
  * If `process.env.DID` is unset, the ucanto server id signer will have a `did()` corresponding to `config.PRIVATE_KEY` (it will be a `did:key` of the corresponding public key)
* Before this PR, many tests of the access-api worker were configured implicitly via dotenv with whatever the `/.env.local` file happened to contain. I added a worker test that asserts functionality that is dependent on the details of the env vars, so I made an affordance for [tests to be able to configure the access-api worker with environment variables defined in the test case itself](https://github.com/web3-storage/w3protocol/pull/275/files#diff-e20ffc550d006747790e7b67da280446c1cd1d2d4f72ccb5df04f62cbb6423daR149).