### PR TITLE
fix: handle Buffer serialization

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -85,7 +85,7 @@
     "@types/assert": "^1.5.6",
     "@types/inquirer": "^9.0.3",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.9",
+    "@types/node": "^18.11.10",
     "@types/ws": "^8.5.3",
     "@ucanto/server": "^4.0.2",
     "assert": "^2.0.0",

--- a/packages/access-client/src/utils/json.js
+++ b/packages/access-client/src/utils/json.js
@@ -11,6 +11,8 @@ export const replacer = (k, v) => {
     return { $map: [...v.entries()] }
   } else if (v instanceof Uint8Array) {
     return { $bytes: [...v.values()] }
+  } else if (v?.type === 'Buffer' && Array.isArray(v.data)) {
+    return { $bytes: v.data }
   }
   return v
 }

--- a/packages/access-client/test/drivers/conf.node.test.js
+++ b/packages/access-client/test/drivers/conf.node.test.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import { Buffer } from 'node:buffer'
 import { ConfDriver } from '../../src/drivers/conf.js'
 
 describe('Conf driver', () => {
@@ -10,5 +11,14 @@ describe('Conf driver', () => {
     assert(data)
     assert.strictEqual(data.foo, undefined)
     assert.strictEqual(data.bar, 1)
+  })
+
+  it('should store a Buffer', async () => {
+    const driver = new ConfDriver({ profile: 'w3protocol-access-client-test' })
+    await driver.reset()
+    await driver.save({ buf: Buffer.from('⁂', 'utf8') })
+    const actual = await driver.load()
+    assert(actual)
+    assert.deepEqual(actual.buf, new TextEncoder().encode('⁂'))
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
       '@types/assert': ^1.5.6
       '@types/inquirer': ^9.0.3
       '@types/mocha': ^10.0.1
-      '@types/node': ^18.11.9
+      '@types/node': ^18.11.10
       '@types/ws': ^8.5.3
       '@ucanto/client': ^4.0.2
       '@ucanto/core': ^4.0.2


### PR DESCRIPTION
Buffer has a toJSON implementation which is called before our replacer function when serialising. It's JSON form is an object like `{ type: 'Buffer, data: number[] }`.

This means it doesn't get identfied as $bytes, and does not get deserialised in the reviver. I think we'd rather have `Uint8Array` everywhere so this PR fixes it so that it gets revived as that.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>