### PR TITLE
chore: fix docs release ci

### DIFF
--- a/.github/workflows/reusable-deploy-docs.yml
+++ b/.github/workflows/reusable-deploy-docs.yml
@@ -9,7 +9,6 @@ jobs:
       pages: write
       id-token: write
     runs-on: ubuntu-latest
-    if: github.event.inputs.package == 'docs'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The release workflow wasnt running the docs job because of an `if` clause leftover from the manual workflow.