### PR TITLE
feat: upload/remove returns removed item

### DIFF
--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -36,7 +36,7 @@ export interface Service {
   upload: {
     add: ServiceMethod<UploadAdd, UploadAddResponse, never>
     list: ServiceMethod<UploadList, ListResponse<UploadListResult>, never>
-    remove: ServiceMethod<UploadRemove, null, never>
+    remove: ServiceMethod<UploadRemove, UploadRemoveResponse | undefined, never>
   }
 }
 
@@ -50,6 +50,8 @@ export interface UploadAddResponse {
   root: AnyLink
   shards?: CARLink[]
 }
+
+export interface UploadRemoveResponse extends UploadAddResponse {}
 
 export interface ListResponse<R> {
   cursor?: string

--- a/packages/upload-client/src/upload.js
+++ b/packages/upload-client/src/upload.js
@@ -151,4 +151,6 @@ export async function remove(
       cause: result,
     })
   }
+
+  return result
 }

--- a/packages/upload-client/test/upload.test.js
+++ b/packages/upload-client/test/upload.test.js
@@ -367,7 +367,7 @@ describe('Upload.remove', () => {
           assert.equal(invCap.can, UploadCapabilities.remove.can)
           assert.equal(invCap.with, space.did())
           assert.equal(String(invCap.nb?.root), car.roots[0].toString())
-          return null
+          return { root: car.roots[0] }
         }),
       },
     })


### PR DESCRIPTION
needed by https://github.com/web3-storage/w3cli/pull/20 to find which shards to also remove when removing an upload

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>