### PR TITLE
fix: access-api ctx.signer no longer uses env.DID. instead env.DID is only used for ucanto server id

### DIFF
--- a/packages/access-api/package.json
+++ b/packages/access-api/package.json
@@ -22,7 +22,6 @@
     "@ucanto/principal": "^4.0.2",
     "@ucanto/server": "^4.0.2",
     "@ucanto/transport": "^4.0.2",
-    "@ucanto/validator": "^4.0.2",
     "@web3-storage/access": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/worker-utils": "0.4.3-dev",

--- a/packages/access-api/src/routes/raw.js
+++ b/packages/access-api/src/routes/raw.js
@@ -8,7 +8,7 @@ import { service } from '../service/index.js'
  */
 export async function postRaw(request, env) {
   const server = Server.create({
-    id: env.signer,
+    id: env.config.ucantoServerId,
     encoder: serverCodec,
     decoder: serverCodec,
     service: service(env),

--- a/packages/access-api/test/config.test.js
+++ b/packages/access-api/test/config.test.js
@@ -19,21 +19,32 @@ const testKeypair = {
 }
 
 describe('@web3-storage/access-api/src/config configureSigner', () => {
+  it('creates a signer using config.PRIVATE_KEY', async () => {
+    const config = {
+      PRIVATE_KEY: testKeypair.private.multiformats,
+    }
+    const signer = configModule.configureSigner(config)
+    assert.ok(signer)
+    assert.equal(signer.did().toString(), testKeypair.public.did)
+    const { keys } = signer.toArchive()
+    const didKeys = Object.keys(keys)
+    assert.deepEqual(didKeys, [testKeypair.public.did])
+  })
+})
+
+describe('@web3-storage/access-api/src/config configureUcantoServerId', () => {
   it('creates a signer using config.{DID,PRIVATE_KEY}', async () => {
     const config = {
       PRIVATE_KEY: testKeypair.private.multiformats,
       DID: 'did:web:exampe.com',
     }
-    const signer = configModule.configureSigner(config)
-    assert.ok(signer)
-    assert.equal(signer.did().toString(), config.DID)
-    const { keys } = signer.toArchive()
-    const didKeys = Object.keys(keys)
-    assert.deepEqual(didKeys, [testKeypair.public.did])
+    const serverId = configModule.configureUcantoServerId(config)
+    assert.ok(serverId)
+    assert.equal(serverId.did().toString(), config.DID)
   })
   it('errors if config.DID is provided but not a did', () => {
     assert.throws(() => {
-      configModule.configureSigner({
+      configModule.configureUcantoServerId({
         DID: 'not a did',
         PRIVATE_KEY: testKeypair.private.multiformats,
       })
@@ -43,8 +54,8 @@ describe('@web3-storage/access-api/src/config configureSigner', () => {
     const config = {
       PRIVATE_KEY: testKeypair.private.multiformats,
     }
-    const signer = configModule.configureSigner(config)
-    assert.ok(signer)
-    assert.equal(signer.did().toString(), testKeypair.public.did)
+    const serverId = configModule.configureUcantoServerId(config)
+    assert.ok(serverId)
+    assert.equal(serverId.did().toString(), testKeypair.public.did)
   })
 })

--- a/packages/access-api/wrangler.toml
+++ b/packages/access-api/wrangler.toml
@@ -28,7 +28,7 @@ database_id = "7c676e0c-b9e7-4711-97c8-7b1c8eb229ae"
 [vars]
 ENV = "dev"
 DEBUG = "true"
-
+DID = "did:web:local.web3.storage"
 
 [build]
 command = "scripts/cli.js build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,6 @@ importers:
       '@ucanto/principal': ^4.0.2
       '@ucanto/server': ^4.0.2
       '@ucanto/transport': ^4.0.2
-      '@ucanto/validator': ^4.0.2
       '@web3-storage/access': workspace:^
       '@web3-storage/capabilities': workspace:^
       '@web3-storage/worker-utils': 0.4.3-dev
@@ -73,7 +72,6 @@ importers:
       '@ucanto/principal': 4.0.2
       '@ucanto/server': 4.0.2
       '@ucanto/transport': 4.0.2
-      '@ucanto/validator': 4.0.2
       '@web3-storage/access': link:../access-client
       '@web3-storage/capabilities': link:../capabilities
       '@web3-storage/worker-utils': 0.4.3-dev


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/302