### PR TITLE
feat: access-api version route sets did=ucantoServerId and adds a signer prop

### DIFF
--- a/packages/access-api/src/routes/version.js
+++ b/packages/access-api/src/routes/version.js
@@ -6,6 +6,7 @@ export async function version(event, env, ctx) {
     version: env.config.VERSION,
     commit: env.config.COMMITHASH,
     branch: env.config.BRANCH,
-    did: env.signer.did(),
+    did: env.config.ucantoServerId.did(),
+    signer: env.signer.did(),
   })
 }


### PR DESCRIPTION
Motivation:
* `@web3-storage/access` cli expects to be able to fetch /version and pull the `did` property in order to create the ucanto Verifier that is used as the `aud` when signing ucans
  * https://github.com/web3-storage/w3protocol/blob/main/packages/access-client/src/cli/utils.js#L28
* before this change, that `did` property came from `ctx.signer`, which will have a `did:key`.
* but since https://github.com/web3-storage/w3protocol/pull/303 , the verifier used in the ucanto server for upload-api is actually different than `ctx.signer.did()`. So this PR makes it so /version `did` property actually comes from `ctx.config.ucantoServerId`
  * it also adds a new key to that endpoint, `signer`, which is the public key of the signer (which now can be different than the `DID` of the ucanto server id). I added this just in case someone wants to use the /version endpoint to know the undelrying signer pubkey
