### PR TITLE
Revert "feat: access-api version route sets did=ucantoServerId and adds a signer prop"

### DIFF
--- a/packages/access-api/src/routes/version.js
+++ b/packages/access-api/src/routes/version.js
@@ -6,7 +6,6 @@ export async function version(event, env, ctx) {
     version: env.config.VERSION,
     commit: env.config.COMMITHASH,
     branch: env.config.BRANCH,
-    did: env.config.ucantoServerId.did(),
-    signer: env.signer.did(),
+    did: env.signer.did(),
   })
 }


### PR DESCRIPTION
Reverts web3-storage/w3protocol#305

Motivation:
* changing `did` to be sometimes `did:web` broke how access-client depended on it