### PR TITLE
feat: include ucanto server principal did as 'aud' key in /version endpoint

### DIFF
--- a/packages/access-api/src/routes/version.js
+++ b/packages/access-api/src/routes/version.js
@@ -6,7 +6,8 @@ export async function version(event, env, ctx) {
     version: env.config.VERSION,
     commit: env.config.COMMITHASH,
     branch: env.config.BRANCH,
-    did: env.config.ucantoServerId.did(),
+    did: env.signer.did(),
+    verifier: env.config.ucantoServerId.did(),
     signer: env.signer.did(),
   })
 }

--- a/packages/access-api/src/routes/version.js
+++ b/packages/access-api/src/routes/version.js
@@ -6,6 +6,7 @@ export async function version(event, env, ctx) {
     version: env.config.VERSION,
     commit: env.config.COMMITHASH,
     branch: env.config.BRANCH,
-    did: env.signer.did(),
+    did: env.config.ucantoServerId.did(),
+    signer: env.signer.did(),
   })
 }

--- a/packages/access-api/src/routes/version.js
+++ b/packages/access-api/src/routes/version.js
@@ -7,7 +7,6 @@ export async function version(event, env, ctx) {
     commit: env.config.COMMITHASH,
     branch: env.config.BRANCH,
     did: env.signer.did(),
-    verifier: env.config.ucantoServerId.did(),
-    signer: env.signer.did(),
+    aud: env.config.ucantoServerId.did(),
   })
 }


### PR DESCRIPTION
Motivation:
* make it easy to discover the ucanto server principal
* unlike [reverted PR](https://github.com/web3-storage/w3protocol/pull/305), don't change `did` property
  * because at least `@web3-storage/access` cli expects to be able to parse that value as a Verifier, which it can only do when the `did` is a `did:key`