### PR TITLE
feat: add `redirect` field to voucher `nb`s

### DIFF
--- a/packages/access-api/src/routes/validate-email.js
+++ b/packages/access-api/src/routes/validate-email.js
@@ -22,19 +22,19 @@ export async function validateEmail(req, env) {
         )
       )
 
-      return new HtmlResponse(
-        (
-          <ValidateEmail
-            delegation={delegation}
-            ucan={req.query.ucan}
-            qrcode={await QRCode.toString(req.query.ucan, {
-              type: 'svg',
-              errorCorrectionLevel: 'M',
-              margin: 10,
-            })}
-          />
-        )
-      )
+      return delegation.capabilities[0].nb.redirect ? Response.redirect(delegation.capabilities[0].nb.redirect) : new HtmlResponse(
+          (
+            <ValidateEmail
+              delegation={delegation}
+              ucan={req.query.ucan}
+              qrcode={await QRCode.toString(req.query.ucan, {
+                type: 'svg',
+                errorCorrectionLevel: 'M',
+                margin: 10,
+              })}
+            />
+          )
+        );
     } catch (error) {
       const err = /** @type {Error} */ (error)
 

--- a/packages/access-api/src/service/voucher-claim.js
+++ b/packages/access-api/src/service/voucher-claim.js
@@ -29,6 +29,7 @@ export function voucherClaimProvider(ctx) {
           space: capability.with,
           identity: capability.nb.identity,
           product: capability.nb.product,
+          redirect: capability.nb.redirect,
         },
         proofs: [proof],
       })

--- a/packages/capabilities/src/voucher.js
+++ b/packages/capabilities/src/voucher.js
@@ -78,6 +78,12 @@ export const claim = base.derive({
        * Optional service DID who's voucher is been requested.
        */
       service: Service.optional(),
+      /**
+       * Optional URL to redirect email validation users who click a link in
+       * their email
+       * TODO: should validate that this is specifically a URL, not any URI
+       */
+      redirect: URI.match({ protocol: 'https:' }).optional(),
     },
     derives: (child, parent) => {
       return (
@@ -117,6 +123,12 @@ export const redeem = voucher.derive({
        * agent to choose space.
        */
       space: URI.match({ protocol: 'did:' }),
+      /**
+       * Optional URL to redirect email validation users who click a link in
+       * their email
+       * TODO: should validate that this is specifically a URL, not any URI
+       */
+      redirect: URI.match({ protocol: 'https:' }).optional(),
     },
     derives: (child, parent) => {
       return (


### PR DESCRIPTION
We'd like to allow clients (especially on the web) to specify a redirect when registering a new space. To do this we add a `redirect` field to `voucher/claim` and `voucher/redeem` and use it to decide whether to send a user to the normal landing page or to redirect them to the specified URL after claiming and redeeming a voucher.

This is my first time in this code, so looking for careful review and suggestions for improvement - happy to write tests, more docs, etc but wanted to validate the approach before I get too deep.