### PR TITLE
feat(access-api): access-api version endpoint has publicKey property

### DIFF
--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -5,6 +5,7 @@ import { Email } from './utils/email.js'
 import { Spaces } from './models/spaces.js'
 import { Validations } from './models/validations.js'
 import { loadConfig } from './config.js'
+import { Signer as EdSigner } from '@ucanto/principal/ed25519'
 
 export {}
 
@@ -42,7 +43,7 @@ export interface Env {
 
 export interface RouteContext {
   log: Logging
-  signer: Signer
+  signer: EdSigner.Signer
   config: ReturnType<typeof loadConfig>
   url: URL
   email: Email

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -119,7 +119,7 @@ export function createAnalyticsEngine() {
  * @param {object} config
  * @param {string} config.PRIVATE_KEY - multiformats private key of primary signing key
  * @param {string} [config.DID] - public DID for the service (did:key:... derived from PRIVATE_KEY if not set)
- * @returns {import('@ucanto/interface').Signer}
+ * @returns {Signer.Signer}
  */
 export function configureSigner(config) {
   const signer = Signer.parse(config.PRIVATE_KEY)

--- a/packages/access-api/src/routes/version.js
+++ b/packages/access-api/src/routes/version.js
@@ -7,5 +7,6 @@ export async function version(event, env, ctx) {
     commit: env.config.COMMITHASH,
     branch: env.config.BRANCH,
     did: env.signer.did(),
+    publicKey: env.signer.verifier.toDIDKey(),
   })
 }


### PR DESCRIPTION
...which is always the underlying did:key publicKey, even if signer.did() is a did:web

Motivation
* https://github.com/web3-storage/w3protocol/issues/316
* historically there has been a `did` property, which is (historically) always a `did:key` (so a public key)
* now we deal with non-key dids like `did:web`. So the did may not be identical to the public key (you have to resolve a `did:web` to determine its pubkeys)
* we should have a property that is explicitly only ever a public key (serialized as a `did:key` string)
  * e.g. for code like this to rely on: https://github.com/web3-storage/w3protocol/blob/main/packages/access-client/src/cli/utils.js#L40 (which I think will break when version endpoint's `did` property is a `did:web`)

Rants
* try to avoid calling things 'did' when you mean 'public key'. Or assuming that things called 'did' will always be a `did:key`
* we often say 'did' or 'did:key' when we mean 'keypair', which is confusing because:
  * 1. a 'did' may have zero keypairs
  * 2. a 'did:key', on its own, has no private key. You can't make a 'signer' from only a `did:key` string.