### PR TITLE
wip: first pass at including space did info in verification email

### DIFF
--- a/packages/access-api/src/service/voucher-claim.js
+++ b/packages/access-api/src/service/voucher-claim.js
@@ -45,6 +45,7 @@ export function voucherClaimProvider(ctx) {
     await ctx.email.sendValidation({
       to: capability.nb.identity.replace('mailto:', ''),
       url,
+      space: inv.capabilities[0].nb.space,
     })
   })
 }

--- a/packages/access-api/src/utils/email.js
+++ b/packages/access-api/src/utils/email.js
@@ -15,7 +15,7 @@ export class Email {
   /**
    * Send validation email with ucan to register
    *
-   * @param {{ to: string; url: string }} opts
+   * @param {{ to: string; url: string, space: string }} opts
    */
   async sendValidation(opts) {
     const rsp = await fetch('https://api.postmarkapp.com/email/withTemplate', {
@@ -30,6 +30,7 @@ export class Email {
           product_name: 'Web3 Storage',
           email: opts.to,
           action_url: opts.url,
+          space_did: opts.space,
         },
       }),
     })


### PR DESCRIPTION
First pass at including space DID info in verification email, per #259:

<img width="784" alt="Screen Shot 2022-12-14 at 4 29 20 PM" src="https://user-images.githubusercontent.com/1113/207744969-e94c341b-8dff-46d8-aea4-96f64441dc89.png">

I think this is unsatisfactory - DIDs aren't designed to be shown to humans and people will likely mostly ignore them. There are a number of potential solutions:

1) Just be ok with showing DIDs to users for now and figure out a more user-friendly solution later. This is probably ok - users who care can look at the DID of the space they just created and then eyeball it against the one in the email. 
2) Use Gravatars of DIDs in the email. We'd need to massage the messaging to make this easy for users to understand, but @alanshaw demonstrated how it can be done in https://github.com/web3-storage/w3ui/pull/128
3) Show the name of the space the user just created. A couple problems with this: 
  a) I don't think we save the name outside of the user's browser at the moment (tho could be wrong.. hope I'm wrong?!) 
  b) users might have multiple spaces with the same name, so this may not be unambiguous

Opening this draft pull request to kick off discussion and design of how we actually want this to work. Please weigh in!

