### PR TITLE
fix: use nullish coalescing for audience

### DIFF
--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -28,7 +28,7 @@ import { REQUEST_RETRIES } from './constants.js'
  * @returns {Promise<import('./types').CARLink>}
  */
 export async function add(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   car,
   options = {}
 ) {
@@ -42,7 +42,7 @@ export async function add(
       return await StoreCapabilities.add
         .invoke({
           issuer,
-          audience,
+          audience: audience ?? servicePrincipal,
           with: resource,
           nb: { link, size: car.size },
           proofs,
@@ -120,7 +120,7 @@ export async function add(
  * @returns {Promise<import('./types').ListResponse<import('./types').StoreListResult>>}
  */
 export async function list(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   options = {}
 ) {
   /* c8 ignore next */
@@ -128,7 +128,7 @@ export async function list(
   const result = await StoreCapabilities.list
     .invoke({
       issuer,
-      audience,
+      audience: audience ?? servicePrincipal,
       with: resource,
       proofs,
       nb: {
@@ -167,7 +167,7 @@ export async function list(
  * @param {import('./types').RequestOptions} [options]
  */
 export async function remove(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   link,
   options = {}
 ) {
@@ -176,7 +176,7 @@ export async function remove(
   const result = await StoreCapabilities.remove
     .invoke({
       issuer,
-      audience,
+      audience: audience ?? servicePrincipal,
       with: resource,
       nb: { link },
       proofs,

--- a/packages/upload-client/src/upload.js
+++ b/packages/upload-client/src/upload.js
@@ -28,7 +28,7 @@ import { REQUEST_RETRIES } from './constants.js'
  * @returns {Promise<import('./types').UploadAddResponse>}
  */
 export async function add(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   root,
   shards,
   options = {}
@@ -40,7 +40,7 @@ export async function add(
       return await UploadCapabilities.add
         .invoke({
           issuer,
-          audience,
+          audience: audience ?? servicePrincipal,
           with: resource,
           nb: { root, shards },
           proofs,
@@ -82,7 +82,7 @@ export async function add(
  * @returns {Promise<import('./types').ListResponse<import('./types').UploadListResult>>}
  */
 export async function list(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   options = {}
 ) {
   /* c8 ignore next */
@@ -91,7 +91,7 @@ export async function list(
   const result = await UploadCapabilities.list
     .invoke({
       issuer,
-      audience,
+      audience: audience ?? servicePrincipal,
       with: resource,
       proofs,
       nb: {
@@ -130,7 +130,7 @@ export async function list(
  * @param {import('./types').RequestOptions} [options]
  */
 export async function remove(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   root,
   options = {}
 ) {
@@ -139,7 +139,7 @@ export async function remove(
   const result = await UploadCapabilities.remove
     .invoke({
       issuer,
-      audience,
+      audience: audience ?? servicePrincipal,
       with: resource,
       nb: { root },
       proofs,


### PR DESCRIPTION
When explicitly passing `null` a default value is not set.