### PR TITLE
chore: remove unnecessary step from api-gateway workflow

### DIFF
--- a/.github/workflows/api-gateway.yml
+++ b/.github/workflows/api-gateway.yml
@@ -35,9 +35,6 @@ jobs:
       url: https://${{ needs.variables.outputs.wrangler_name }}.protocol-labs.workers.dev
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          echo variables
-          echo "needs.variables.outputs.wrangler_name=${{ needs.variables.outputs.wrangler_name }}"
       - uses: pnpm/action-setup@v2.2.3
         with:
           version: 7


### PR DESCRIPTION
Motivation:
* testing workflow for when this source branch is deleted after PR merge (it should call `wrangler delete`)