### PR TITLE
chore: specify pnpm in packageManager for corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
     "depcheck": "^1.4.3",
     "typedoc": "^0.23.22",
     "typedoc-plugin-missing-exports": "^1.0.0"
-  }
+  },
+  "packageManager": "pnpm@7.24.3"
 }


### PR DESCRIPTION
I'm on the fence about this PR but figured I'd open it for review/discussion — feel free to close!

The README specifies "We use `pnpm` in this project" and node.js has some (experimental) support for actually capturing and using that metadata (see https://nodejs.org/api/corepack.html#configuring-a-package).

Notes:

* frankly the full implications here are unclear to me but it seems a relatively harmless to capture this programmatically rather than just in the README
* testing against node v18.12.1 with this in place, and after I `corepack enable` then `pnpm --version` reflects whatever version is currently in the package.json in some sort of `npx` style auto-install fashion
* it does not seem to be possible to specify a flexible version like ^7.24.3 or even a more generic pnpm@7 without causing it to complain about semver formatting