### PR TITLE
chore: apply most of recommended eslintConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,17 @@
     "typescript": "4.9.4",
     "wrangler": "^2.6.2"
   },
+  "eslintConfig": {
+    "extends": [
+      "./node_modules/hd-scripts/eslint/index.js"
+    ],
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "ignorePatterns": [
+      "dist"
+    ]
+  },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },


### PR DESCRIPTION
The README currently instructs developers to manually apply the `eslintConfig` to a locally-modified package.json. That seems a bit of a headache to then leave out of every subsequent commit and it's unclear the advantage of not just applying it in the repo?

In this commit I've applied what is labelled as the **non-optional** parts to simply be in the package.json without needing further intervention.