### PR TITLE
docs: smooth out on-boarding for local API testing

### DIFF
--- a/packages/access-api/readme.md
+++ b/packages/access-api/readme.md
@@ -17,7 +17,7 @@ pnpm run lint
 pnpm run test
 ```
 
-The API server is currently hardcoded to listen on port 8787 on unspecified (i.e. typically: all) network interfaces.
+The dev API server is currently hardcoded to listen on port 8787 on unspecified (i.e. typically: all) network interfaces.
 
 ## Migrations
 

--- a/packages/access-api/readme.md
+++ b/packages/access-api/readme.md
@@ -4,6 +4,7 @@
 ## Development
 
 Run the root [instructions](../../readme.md#setup-a-development-environment) first.
+Review the repo-wide `.env` file copied in those steps and fill in real API keys for any services you plan to test against.
 
 ```bash
 # Run api locally
@@ -15,6 +16,8 @@ pnpm run lint
 # Run tests
 pnpm run test
 ```
+
+The API server is currently hardcoded to listen on port 8787 on unspecified (i.e. typically: all) network interfaces.
 
 ## Migrations
 

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ npx simple-git-hooks
 cp .env.tpl .env
 ```
 
+The individual packages may have additional setup instructions, and include specific usage information.
+You are also encouraged to set up your IDE with linting and formatting to ensure your commits can be merged.
+
 ### Vscode config
 
 Install these extensions
@@ -57,8 +60,6 @@ Add these lines to your vscode workspace settings at `.vscode/settings.json`
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
 ```
-
-Each package has it's own readme with specific instructions.
 
 ## Release Process
 


### PR DESCRIPTION
I've added a few more tips/hints to get someone from a fresh checkout to accessing their own dev version of the API server. Should be no impact on the more public-facing (client library) documentation, just clarifying/extending the local environment setup notes.