### PR TITLE
chore: add current email templates to repo for reference/tracking

### DIFF
--- a/packages/access-api/postmark/README.md
+++ b/packages/access-api/postmark/README.md
@@ -1,0 +1,12 @@
+## Postmark templates
+
+These are provided here for reference and version tracking.
+
+Before use they must be manually configured in the Postmark account: 
+
+1. In Postmark account, choose Server, then go to Templates tab: <https://account.postmarkapp.com/servers/${some_id}/templates>
+2. Initial setup: add template if necessary, "Code your own" and your choice of existing/new or "Don't use a layout".
+3. The name of the template is not critical, but the "Alias" configuration link must be set to match the file name(s) in this directory. The subject should be set if provided here.
+4. There are two tabs in Postmark's editor, copy-paste both the HTML and Text versions for a given template.
+
+Please make sure to keep the files here up-to-date with any edits you might make from the Postmark dashboard.

--- a/packages/access-api/postmark/welcome.html
+++ b/packages/access-api/postmark/welcome.html
@@ -1,0 +1,41 @@
+
+<p>Hi {{email}}! To complete your {{product_name}} registration, we just need to verify your email address.</p>
+<!-- Action -->
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="center">
+      <!-- Border based button https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center">
+            <table border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td>
+                  <a href="{{action_url}}" class="button button--purple" target="_blank">Verify email address</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<p>Once verified, you can continue your registration process.</p>
+
+<!-- Sub copy -->
+<table class="body-sub">
+  <tr>
+    <td>
+      <div style="box-sizing:border-box;display:block;max-width:580px;margin:0 auto">
+        <p class="sub">Button not working? Paste the following link into your browser: <a href="{{action_url}}">{{action_url}}</a></p>
+      </div>
+      
+    </td>
+  </tr>
+  <tr>
+     <td>
+      <p class="sub">You're receiving this email because you recently started a registration with <b>{{product_name}}</b>. If this wasn't you, please ignore this email.</p>
+    </td>
+  </tr>
+</table>

--- a/packages/access-api/postmark/welcome.txt
+++ b/packages/access-api/postmark/welcome.txt
@@ -1,0 +1,33 @@
+******************
+Welcome, {{name}}!
+******************
+
+
+## Hugo
+
+Thanks for trying {{product_name}}. We're thrilled to have you on board.
+
+To get the most out of {{product_name}}, do this primary next step:
+
+Do this Next ( {{ action_url }} )
+
+For reference, here's your login information: fffffffffff
+
+Login Page: {{login_url}}
+Username: {{username}}
+
+You've started a {{trial_length}} day trial. You can upgrade to a paying account or cancel any time.
+
+Trial Start Date: {{trial_start_date}}
+Trial End Date: {{trial_end_date}}
+
+If you have any questions, feel free to email our customer success team ( {{ support_email }} ). (We're lightning quick at replying.) We also offer live chat ( {{ live_chat_url }} ) during business hours.
+
+Thanks,
+{{sender_name}} and the {{product_name}} Team
+
+P.S. Need immediate help getting started? Check out our help documentation ( {{ help_url }} ). Or, just reply to this email, the {{product_name}} support team is always ready to help!
+
+If you're having trouble with the button above, copy and paste the URL below into your web browser.
+
+{{action_url}}


### PR DESCRIPTION
This adds copies of the current Postmark `TemplateAlias: 'welcome'` content, shared by @travis via:

* https://filecoinproject.slack.com/archives/C04J6BGPULQ/p1673985987052709?thread_ts=1673648573.433349&cid=C04J6BGPULQ (html)
* https://filecoinproject.slack.com/archives/C04J6BGPULQ/p1673986008694189?thread_ts=1673648573.433349&cid=C04J6BGPULQ (text)

For the purposes of this PR please do **not** review the actual content! There are some known issues with the current plaintext template that will need to be addressed (xref https://filecoinproject.slack.com/archives/C02BZPRS9HP/p1673986091876469 / #356) and some future enhancements being discussed. But those are examples of things that would be nice to have a commit history for going forward.

The goal of this change is simply to capture the current *status quo* in the repository, rather than lost/hidden within the Postmark account.
