### PR TITLE
changes to how upload-api proxying works

### DIFF
--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -21,8 +21,12 @@ import * as uploadApi from './upload-api-proxy.js'
  */
 export function service(ctx) {
   return {
-    store: uploadApi.createStoreProxy(ctx),
-    upload: uploadApi.createUploadProxy(ctx),
+    store: uploadApi.createStoreProxy({
+      uploadApi: ctx.uploadApi,
+    }),
+    upload: uploadApi.createUploadProxy({
+      uploadApi: ctx.uploadApi,
+    }),
 
     voucher: {
       claim: voucherClaimProvider(ctx),

--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -21,12 +21,8 @@ import * as uploadApi from './upload-api-proxy.js'
  */
 export function service(ctx) {
   return {
-    store: uploadApi.createStoreProxy({
-      uploadApi: ctx.uploadApi,
-    }),
-    upload: uploadApi.createUploadProxy({
-      uploadApi: ctx.uploadApi,
-    }),
+    store: uploadApi.createStoreProxy(ctx),
+    upload: uploadApi.createUploadProxy(ctx),
 
     voucher: {
       claim: voucherClaimProvider(ctx),

--- a/packages/access-api/src/service/upload-api-proxy.js
+++ b/packages/access-api/src/service/upload-api-proxy.js
@@ -84,12 +84,10 @@ function getDefaultConnections(options) {
       ...(uploadApi.production && { url: uploadApi.production }),
       fetch,
     }),
-    ...(uploadApi.staging && {
-      [uploadApiEnvironments.staging.audience]: createUcantoHttpConnection({
-        ...uploadApiEnvironments.staging,
-        url: uploadApi.staging,
-        fetch,
-      }),
+    [uploadApiEnvironments.staging.audience]: createUcantoHttpConnection({
+      ...uploadApiEnvironments.staging,
+      url: uploadApi.staging ?? uploadApiEnvironments.staging.url,
+      fetch,
     }),
   }
 }


### PR DESCRIPTION
* route `aud=did:web:staging.web3.storage` invocations to https://staging.up.web3.storage even if `env.UPLOAD_API_URL_STAGING` isn't set
  * This will make it easier to iterate and get this working against staging upload-api without having to use production secrets
