### PR TITLE
fix: upload-api-proxy default fetch binds to globalThis

### DIFF
--- a/packages/access-api/src/service/upload-api-proxy.js
+++ b/packages/access-api/src/service/upload-api-proxy.js
@@ -77,7 +77,7 @@ const uploadApiEnvironments = {
  * @param {URL} [options.uploadApi.staging]
  */
 function getDefaultConnections(options) {
-  const { fetch = globalThis.fetch, uploadApi } = options
+  const { fetch = globalThis.fetch.bind(globalThis), uploadApi } = options
   return {
     default: createUcantoHttpConnection({
       ...uploadApiEnvironments.production,


### PR DESCRIPTION
Motivation:
* attempt to fix according to this theory https://github.com/web3-storage/w3protocol/issues/359#issuecomment-1386434483