### PR TITLE
fix: debug logging describeFetch does not access `response.type`

### DIFF
--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -204,7 +204,6 @@ async function describeFetch(response, fetchArgs) {
   return {
     request: fetchArgs,
     response: {
-      type: response.type,
       ok: response.ok,
       redirected: response.redirected,
       headers: [...response.headers],


### PR DESCRIPTION
 because it will throw an [error](https://sentry.io/organizations/protocol-labs-it/issues/3885402347/?project=6536511&query=is%3Aunresolved&referrer=issue-stream) when accessed
`Failed to get the 'type' property on 'Response': the property is not implemented.`