### PR TITLE
feat: add /reproduce-cloudflare-error route to access-api

### DIFF
--- a/packages/access-api/src/service/upload-api-proxy.js
+++ b/packages/access-api/src/service/upload-api-proxy.js
@@ -16,7 +16,7 @@ import { createProxyHandler } from '../ucanto/proxy.js'
  * @template {string|number|symbol} M
  * @template {Ucanto.ConnectionView<any>} [Connection=Ucanto.ConnectionView<any>]
  * @param {object} options
- * @param {Ucanto.Signer} [options.signer]
+ * @param {Ucanto.Signer} options.signer
  * @param {Array<M>} options.methods
  * @param {{ default: Connection } & Record<Ucanto.UCAN.DID, Connection>} options.connections
  */
@@ -97,7 +97,7 @@ function getDefaultConnections(options) {
 /**
  * @template {Ucanto.ConnectionView<any>} [Connection=Ucanto.ConnectionView<any>]
  * @param {object} options
- * @param {Ucanto.Signer} [options.signer]
+ * @param {Ucanto.Signer} options.signer
  * @param {typeof globalThis.fetch} [options.fetch]
  * @param {{ default: Connection, [K: Ucanto.UCAN.DID]: Connection }} [options.connections]
  * @param {Record<Ucanto.UCAN.DID, URL>} [options.audienceToUrl]
@@ -116,7 +116,7 @@ export function createUploadProxy(options) {
 /**
  * @template {Ucanto.ConnectionView<any>} [Connection=Ucanto.ConnectionView<any>]
  * @param {object} options
- * @param {Ucanto.Signer} [options.signer]
+ * @param {Ucanto.Signer} options.signer
  * @param {typeof globalThis.fetch} [options.fetch]
  * @param {{ default: Connection, [K: Ucanto.UCAN.DID]: Connection }} [options.connections]
  * @param {Record<Ucanto.UCAN.DID, URL>} [options.audienceToUrl]

--- a/packages/access-api/src/service/upload-api-proxy.js
+++ b/packages/access-api/src/service/upload-api-proxy.js
@@ -56,7 +56,9 @@ function createUcantoHttpConnection(options) {
 const uploadApiEnvironments = {
   production: {
     audience: /** @type {const} */ ('did:web:web3.storage'),
-    url: new URL('https://up.web3.storage'),
+    // dont use up.web3.storage because it won't resolve from inside cloudflare workers
+    // until resolution of https://github.com/web3-storage/w3protocol/issues/363
+    url: new URL('https://3bd9h7xn3j.execute-api.us-west-2.amazonaws.com/'),
   },
   staging: {
     audience: /** @type {const} */ ('did:web:staging.web3.storage'),

--- a/packages/access-api/src/ucanto/proxy.js
+++ b/packages/access-api/src/ucanto/proxy.js
@@ -47,7 +47,7 @@ function defaultCatchInvocationError(error) {
  * @param {object} options
  * @param {(error: unknown) => Promise<unknown>} [options.catchInvocationError] - catches any error that comes from invoking the proxy invocation on the connection. If it returns a value, that value will be the proxied invocation result.
  * @param {{ default: Connection, [K: Ucanto.UCAN.DID]: Connection }} options.connections
- * @param {Ucanto.Signer} [options.signer]
+ * @param {Ucanto.Signer} options.signer
  */
 export function createProxyHandler(options) {
   /**
@@ -64,17 +64,8 @@ export function createProxyHandler(options) {
     } = options
     const { audience, capabilities, expiration, notBefore } = invocationIn
     const connection = connections[audience.did()] ?? connections.default
-    // eslint-disable-next-line unicorn/prefer-logical-operator-over-ternary, no-unneeded-ternary
-    const proxyInvocationIssuer = signer
-      ? // this results in a forwarded invocation, but the upstream will reject the signature
-        // created using options.signer unless options.signer signs w/ the same private key as the original issuer
-        // and it'd be nice to not even have to pass around `options.signer`
-        signer
-      : // this works, but involves lying about the issuer type (it wants a Signer but context.id is only a Verifier)
-        // @todo obviate this type override via https://github.com/web3-storage/ucanto/issues/195
-        /** @type {Ucanto.Signer} */ (context.id)
     const proxyInvocation = Client.invoke({
-      issuer: proxyInvocationIssuer,
+      issuer: signer,
       capability: capabilities[0],
       audience,
       proofs: [invocationIn],

--- a/packages/access-api/test/ucanto-proxy.test.js
+++ b/packages/access-api/test/ucanto-proxy.test.js
@@ -45,6 +45,7 @@ describe('ucanto-proxy', () => {
       service: {
         test: {
           succeed: createProxyHandler({
+            signer: proxyPrincipal,
             connections: {
               default: Client.connect({
                 id: upstreamPrincipal,
@@ -116,6 +117,7 @@ describe('ucanto-proxy', () => {
       service: {
         test: {
           succeed: createProxyHandler({
+            signer: upstreamPrincipal,
             connections: {
               default: Client.connect({
                 id: upstreamPrincipal,


### PR DESCRIPTION
Motivation:
* cloudflare support asked for a URL to reproduce the undelrying cause of #363 
* this adds a route just for that. once they use it to reproduce and diagnose, we remove it