### PR TITLE
feat: access-api handling store/info for space not in db returns failure with name

### DIFF
--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -33,11 +33,13 @@ export function service(ctx) {
       info: Server.provide(Space.info, async ({ capability, invocation }) => {
         const results = await ctx.models.spaces.get(capability.with)
         if (!results) {
-          return {
+          /** @type {import('@web3-storage/access/types').SpaceUnknown} */
+          const spaceUnknownFailure = {
             error: true,
-            status: 404,
-            message: 'Space not found.',
+            name: 'SpaceUnknown',
+            message: `Space not found.`,
           }
+          return spaceUnknownFailure
         }
         return results
       }),

--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -33,7 +33,11 @@ export function service(ctx) {
       info: Server.provide(Space.info, async ({ capability, invocation }) => {
         const results = await ctx.models.spaces.get(capability.with)
         if (!results) {
-          return new Failure('Space not found.')
+          return {
+            error: true,
+            status: 404,
+            message: 'Space not found.',
+          }
         }
         return results
       }),

--- a/packages/access-api/test/space-info.test.js
+++ b/packages/access-api/test/space-info.test.js
@@ -28,10 +28,11 @@ describe('space/info', function () {
 
     if (inv?.error) {
       assert.deepEqual(inv.message, `Space not found.`)
+      const expectedErrorName = 'SpaceUnknown'
       assert.deepEqual(
-        'status' in inv && inv.status,
-        404,
-        'error result has status 404'
+        'name' in inv && inv.name,
+        expectedErrorName,
+        `error result has name ${expectedErrorName}`
       )
     } else {
       assert.fail()

--- a/packages/access-api/test/space-info.test.js
+++ b/packages/access-api/test/space-info.test.js
@@ -28,6 +28,11 @@ describe('space/info', function () {
 
     if (inv?.error) {
       assert.deepEqual(inv.message, `Space not found.`)
+      assert.deepEqual(
+        'status' in inv && inv.status,
+        404,
+        'error result has status 404'
+      )
     } else {
       assert.fail()
     }

--- a/packages/access-client/src/errors.ts
+++ b/packages/access-client/src/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Indicates failure executing ability that requires access to a space that is not well-known enough to be handled.
+ * e.g. it's a space that's never been seen before,
+ * or it's a seen space that hasn't been fully registered such that the service can serve info about the space.
+ */
+export interface SpaceUnknown {
+  error: true
+  message: string
+  name: 'SpaceUnknown'
+}

--- a/packages/access-client/src/errors.ts
+++ b/packages/access-client/src/errors.ts
@@ -1,9 +1,11 @@
+import * as Ucanto from '@ucanto/interface'
+
 /**
  * Indicates failure executing ability that requires access to a space that is not well-known enough to be handled.
  * e.g. it's a space that's never been seen before,
  * or it's a seen space that hasn't been fully registered such that the service can serve info about the space.
  */
-export interface SpaceUnknown {
+export interface SpaceUnknown extends Ucanto.Failure {
   error: true
   message: string
   name: 'SpaceUnknown'

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -35,9 +35,11 @@ import type {
 import type { SetRequired } from 'type-fest'
 import { Driver } from './drivers/types.js'
 import type { ColumnType, Selectable } from 'kysely'
+import { SpaceUnknown } from './errors.js'
 
 // export other types
 export * from '@web3-storage/capabilities/types'
+export * from './errors.js'
 
 /**
  * D1 Types
@@ -61,13 +63,6 @@ export interface SpaceTableMetadata {
 }
 
 /**
- * Indicates failure executing ability that requires access to a space that cannot be found by the handler
- */
-export type SpaceNotFoundFailure = Failure & {
-  status: 404
-}
-
-/**
  * Access api service definition type
  */
 export interface Service {
@@ -83,7 +78,7 @@ export interface Service {
     info: ServiceMethod<
       SpaceInfo,
       Selectable<SpaceTable>,
-      Failure | SpaceNotFoundFailure
+      Failure | SpaceUnknown
     >
     'recover-validation': ServiceMethod<
       SpaceRecoverValidation,

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -61,6 +61,13 @@ export interface SpaceTableMetadata {
 }
 
 /**
+ * Indicates failure executing ability that requires access to a space that cannot be found by the handler
+ */
+export type SpaceNotFoundFailure = Failure & {
+  status: 404
+}
+
+/**
  * Access api service definition type
  */
 export interface Service {
@@ -73,7 +80,11 @@ export interface Service {
     redeem: ServiceMethod<VoucherRedeem, void, Failure>
   }
   space: {
-    info: ServiceMethod<SpaceInfo, Selectable<SpaceTable>, Failure>
+    info: ServiceMethod<
+      SpaceInfo,
+      Selectable<SpaceTable>,
+      Failure | SpaceNotFoundFailure
+    >
     'recover-validation': ServiceMethod<
       SpaceRecoverValidation,
       EncodedDelegation<[SpaceRecover]> | undefined,


### PR DESCRIPTION
Motivation:
* implement https://github.com/web3-storage/w3protocol/issues/382
  * tl;dr `space/info` now has explicit failure type for case where the ucans are valid, but the space DID is not in the db. that way when upload-api invokes `space/info` as part of its `verifyInvocation` logic, it can distinguish between an invalid invocation and a not-found space id

Unblocks:
* this test passing https://github.com/gobengo/w3protocol-test/pull/1
* rest of https://github.com/web3-storage/w3infra/issues/134#user-content-implementation