### PR TITLE
fix: avoid email delegation via GET request

### DIFF
--- a/packages/access-api/src/index.js
+++ b/packages/access-api/src/index.js
@@ -4,7 +4,7 @@ import { notFound } from '@web3-storage/worker-utils/response'
 import { Router } from '@web3-storage/worker-utils/router'
 import { postRaw } from './routes/raw.js'
 import { postRoot } from './routes/root.js'
-import { validateEmail } from './routes/validate-email.js'
+import { preValidateEmail, validateEmail } from './routes/validate-email.js'
 import { validateWS } from './routes/validate-ws.js'
 import { version } from './routes/version.js'
 import { getContext } from './utils/context.js'
@@ -14,7 +14,8 @@ const r = new Router({ onNotFound: notFound })
 
 r.add('options', '*', preflight)
 r.add('get', '/version', version)
-r.add('get', '/validate-email', validateEmail)
+r.add('get', '/validate-email', preValidateEmail)
+r.add('post', '/validate-email', validateEmail)
 r.add('get', '/validate-ws', validateWS)
 r.add('post', '/', postRoot)
 r.add('post', '/raw', postRaw)

--- a/packages/access-api/src/routes/validate-email.js
+++ b/packages/access-api/src/routes/validate-email.js
@@ -4,7 +4,22 @@ import {
   HtmlResponse,
   ValidateEmail,
   ValidateEmailError,
+  PendingValidateEmail,
 } from '../utils/html.js'
+
+/**
+ * @param {import('@web3-storage/worker-utils/router').ParsedRequest} req
+ * @param {import('../bindings.js').RouteContext} env
+ */
+export async function preValidateEmail(req, env) {
+  if (!req.query?.ucan) {
+    return new HtmlResponse(
+      <ValidateEmailError msg={'Missing delegation in the URL.'} />
+    )
+  }
+
+  return new HtmlResponse(<PendingValidateEmail autoApprove={true} />)
+}
 
 /**
  * @param {import('@web3-storage/worker-utils/router').ParsedRequest} req

--- a/packages/access-api/src/utils/html.js
+++ b/packages/access-api/src/utils/html.js
@@ -99,6 +99,40 @@ export class HtmlResponse extends Response {
 
 /**
  *
+ * @param {object} props
+ * @param {boolean} [props.autoApprove]
+ */
+export const PendingValidateEmail = ({ autoApprove }) => (
+  <div class="fcenter">
+    <img
+      src="https://web3.storage/android-chrome-512x512.png"
+      height="80"
+      width="80"
+    />
+    <div>
+      <h1>Validating Email</h1>
+      <form id="approval" method="post" class="fcenter">
+        <button class="mcenter">Approve</button>
+      </form>
+      {autoApprove ? (
+        <script
+          dangerouslySetInnerHTML={{
+            // NOTE: this script sticks to ES3-era syntax for compat with more browsers
+            __html: `(function () {
+            // auto-submit the form for any user w/JS enabled
+            var form = document.getElementById('approval');
+            form.style.display = 'none';
+            form.submit();
+          })();`,
+          }}
+        />
+      ) : undefined}
+    </div>
+  </div>
+)
+
+/**
+ *
  * @param {object} param0
  * @param {Ucanto.Delegation<[import('@web3-storage/capabilities/types').VoucherClaim]> | Ucanto.Delegation<[import('@web3-storage/capabilities/types').SpaceRecover]>} param0.delegation
  * @param {string} param0.ucan

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -23,8 +23,8 @@
   },
   "exports": {
     ".": "./src/index.js",
-    "./types": "./dist/src/types.d.ts",
-    "./*": "./src/*.js"
+    "./*": "./src/*.js",
+    "./types": "./dist/src/types.d.ts"
   },
   "typesVersions": {
     "*": {
@@ -34,20 +34,23 @@
       "store": [
         "dist/src/store"
       ],
-      "types": [
-        "dist/src/types"
-      ],
       "top": [
         "dist/src/top"
       ],
       "upload": [
         "dist/src/upload"
       ],
+      "voucher": [
+        "dist/src/voucher"
+      ],
+      "access": [
+        "dist/src/access"
+      ],
       "utils": [
         "dist/src/utils"
       ],
-      "voucher": [
-        "dist/src/voucher"
+      "types": [
+        "dist/src/types"
       ]
     }
   },

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -1,0 +1,102 @@
+/**
+ * Access Capabilities
+ *
+ * These can be imported directly with:
+ * ```js
+ * import * as Access from '@web3-storage/capabilities/access'
+ * ```
+ *
+ * @module
+ */
+import { capability, URI, DID } from '@ucanto/validator'
+// @ts-ignore
+// eslint-disable-next-line no-unused-vars
+import * as Types from '@ucanto/interface'
+import { equalWith, fail, equal } from './utils.js'
+import { top } from './top.js'
+
+export { top }
+
+/**
+ * Account identifier.
+ */
+export const As = DID.match({ method: 'mailto' })
+
+/**
+ * Capability can only be delegated (but not invoked) allowing audience to
+ * derived any `access/` prefixed capability for the agent identified
+ * by did:key in the `with` field.
+ */
+export const access = top.derive({
+  to: capability({
+    can: 'access/*',
+    with: URI.match({ protocol: 'did:' }),
+    derives: equalWith,
+  }),
+  derives: equalWith,
+})
+
+const base = top.or(access)
+
+/**
+ * Capability can be invoked by an agent to request a `./update` for an account.
+ *
+ * `with` field identifies requesting agent, which MAY be different from iss field identifying issuing agent.
+ */
+export const authorize = base.derive({
+  to: capability({
+    can: 'access/authorize',
+    with: URI.match({ protocol: 'did:' }),
+    nb: {
+      /**
+       * Value MUST be a did:mailto identifier of the account
+       * that the agent wishes to represent via did:key in the `with` field.
+       * It MUST be a valid did:mailto identifier.
+       */
+      as: As,
+    },
+    derives: (child, parent) => {
+      return (
+        fail(equalWith(child, parent)) ||
+        fail(equal(child.nb.as, parent.nb.as, 'as')) ||
+        true
+      )
+    },
+  }),
+  /**
+   * `access/authorize` can be derived from the `access/*` & `*` capability
+   * as long as the `with` fields match.
+   */
+  derives: equalWith,
+})
+
+/**
+ * Issued by trusted authority (usually the one handling invocation that contains this proof) 
+ * to the account (aud) to update invocation local state of the document.
+ *
+ * @see https://github.com/web3-storage/specs/blob/main/w3-account.md#update
+ * 
+ * @example
+ * ```js
+ * {
+    iss: "did:web:web3.storage",
+    aud: "did:mailto:alice@web.mail",
+    att: [{
+      with: "did:web:web3.storage",
+      can: "./update",
+      nb: { key: "did:key:zAgent" }
+    }],
+    exp: null
+    sig: "..."
+  }
+ * ```
+ */
+export const session = capability({
+  can: './update',
+  // Should be web3.storage DID
+  with: URI.match({ protocol: 'did:' }),
+  nb: {
+    // Agent DID so it can sign UCANs as did:mailto if it matches this delegation `aud`
+    key: DID.match({ method: 'key' }),
+  },
+})

--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -3,6 +3,7 @@ import * as Top from './top.js'
 import * as Store from './store.js'
 import * as Upload from './upload.js'
 import * as Voucher from './voucher.js'
+import * as Access from './access.js'
 import * as Utils from './utils.js'
 
 export { Space, Top, Store, Upload, Voucher, Utils }
@@ -24,4 +25,7 @@ export const abilitiesAsStrings = [
   Store.list.can,
   Voucher.claim.can,
   Voucher.redeem.can,
+  Access.access.can,
+  Access.authorize.can,
+  Access.session.can,
 ]

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -5,6 +5,14 @@ import { top } from './top.js'
 import { add, list, remove, store } from './store.js'
 import * as UploadCaps from './upload.js'
 import { claim, redeem } from './voucher.js'
+import * as AccessCaps from './access.js'
+
+// Access
+export type Access = InferInvokedCapability<typeof AccessCaps.access>
+export type AccessAuthorize = InferInvokedCapability<
+  typeof AccessCaps.authorize
+>
+export type AccessSession = InferInvokedCapability<typeof AccessCaps.session>
 
 // Space
 export type Space = InferInvokedCapability<typeof space>
@@ -47,5 +55,8 @@ export type AbilitiesArray = [
   StoreRemove['can'],
   StoreList['can'],
   VoucherClaim['can'],
-  VoucherRedeem['can']
+  VoucherRedeem['can'],
+  Access['can'],
+  AccessAuthorize['can'],
+  AccessSession['can']
 ]

--- a/packages/capabilities/test/capabilities/access.test.js
+++ b/packages/capabilities/test/capabilities/access.test.js
@@ -1,0 +1,225 @@
+import assert from 'assert'
+import { access } from '@ucanto/validator'
+import { Verifier } from '@ucanto/principal/ed25519'
+import * as Access from '../../src/access.js'
+import { alice, bob, service, mallory } from '../helpers/fixtures.js'
+
+describe('access capabilities', function () {
+  it('should self issue', async function () {
+    const agent = mallory
+    const auth = Access.authorize.invoke({
+      issuer: agent,
+      audience: service,
+      with: agent.did(),
+      nb: {
+        as: 'did:mailto:web3.storage:test',
+      },
+    })
+
+    const result = await access(await auth.delegate(), {
+      capability: Access.authorize,
+      principal: Verifier,
+      authority: service,
+    })
+    if (result.error) {
+      assert.fail('error in self issue')
+    } else {
+      assert.deepEqual(result.audience.did(), service.did())
+      assert.equal(result.capability.can, 'access/authorize')
+      assert.deepEqual(result.capability.nb, {
+        as: 'did:mailto:web3.storage:test',
+      })
+    }
+  })
+
+  it('should delegate from authorize to authorize', async function () {
+    const agent1 = bob
+    const agent2 = mallory
+    const claim = Access.authorize.invoke({
+      issuer: agent2,
+      audience: service,
+      with: agent1.did(),
+      nb: {
+        as: 'did:mailto:web3.storage:test',
+      },
+      proofs: [
+        await Access.authorize.delegate({
+          issuer: agent1,
+          audience: agent2,
+          with: agent1.did(),
+          nb: {
+            as: 'did:mailto:web3.storage:test',
+          },
+        }),
+      ],
+    })
+
+    const result = await access(await claim.delegate(), {
+      capability: Access.authorize,
+      principal: Verifier,
+      authority: service,
+    })
+
+    if (result.error) {
+      assert.fail('should not error')
+    } else {
+      assert.deepEqual(result.audience.did(), service.did())
+      assert.equal(result.capability.can, 'access/authorize')
+      assert.deepEqual(result.capability.nb, {
+        as: 'did:mailto:web3.storage:test',
+      })
+    }
+  })
+
+  it('should delegate from authorize/* to authorize', async function () {
+    const agent1 = bob
+    const agent2 = mallory
+    const claim = Access.authorize.invoke({
+      issuer: agent2,
+      audience: service,
+      with: agent1.did(),
+      nb: {
+        as: 'did:mailto:web3.storage:test',
+      },
+      proofs: [
+        await Access.access.delegate({
+          issuer: agent1,
+          audience: agent2,
+          with: agent1.did(),
+        }),
+      ],
+    })
+
+    const result = await access(await claim.delegate(), {
+      capability: Access.authorize,
+      principal: Verifier,
+      authority: service,
+    })
+
+    if (result.error) {
+      assert.fail('should not error')
+    } else {
+      assert.deepEqual(result.audience.did(), service.did())
+      assert.equal(result.capability.can, 'access/authorize')
+      assert.deepEqual(result.capability.nb, {
+        as: 'did:mailto:web3.storage:test',
+      })
+    }
+  })
+  it('should delegate from * to authorize', async function () {
+    const agent1 = bob
+    const agent2 = mallory
+    const claim = Access.authorize.invoke({
+      issuer: agent2,
+      audience: service,
+      with: agent1.did(),
+      nb: {
+        as: 'did:mailto:web3.storage:test',
+      },
+      proofs: [
+        await Access.top.delegate({
+          issuer: agent1,
+          audience: agent2,
+          with: agent1.did(),
+        }),
+      ],
+    })
+
+    const result = await access(await claim.delegate(), {
+      capability: Access.authorize,
+      principal: Verifier,
+      authority: service,
+    })
+
+    if (result.error) {
+      assert.fail('should not error')
+    } else {
+      assert.deepEqual(result.audience.did(), service.did())
+      assert.equal(result.capability.can, 'access/authorize')
+      assert.deepEqual(result.capability.nb, {
+        as: 'did:mailto:web3.storage:test',
+      })
+    }
+  })
+
+  it('should error auth to auth when caveats are different', async function () {
+    const agent1 = bob
+    const agent2 = mallory
+    const claim = Access.authorize.invoke({
+      issuer: agent2,
+      audience: service,
+      with: agent1.did(),
+      nb: {
+        as: 'did:mailto:web3.storage:ANOTHER_TEST',
+      },
+      proofs: [
+        await Access.authorize.delegate({
+          issuer: agent1,
+          audience: agent2,
+          with: agent1.did(),
+          nb: {
+            as: 'did:mailto:web3.storage:test',
+          },
+        }),
+      ],
+    })
+
+    const result = await access(await claim.delegate(), {
+      capability: Access.authorize,
+      principal: Verifier,
+      authority: service,
+    })
+
+    if (result.error) {
+      assert.ok(result.message.includes('- Can not derive'))
+    } else {
+      assert.fail('should error')
+    }
+  })
+
+  it('should error if with dont match', async function () {
+    const agent1 = bob
+    const agent2 = mallory
+    const claim = Access.authorize.invoke({
+      issuer: agent2,
+      audience: service,
+      with: alice.did(),
+      nb: {
+        as: 'did:mailto:web3.storage:test',
+      },
+      proofs: [
+        await Access.top.delegate({
+          issuer: agent1,
+          audience: agent2,
+          with: agent1.did(),
+        }),
+      ],
+    })
+
+    const result = await access(await claim.delegate(), {
+      capability: Access.authorize,
+      principal: Verifier,
+      authority: service,
+    })
+
+    if (result.error) {
+      assert.ok(result.message.includes('- Can not derive'))
+    } else {
+      assert.fail('should error')
+    }
+  })
+
+  it('should fail validation if its not mailto', async function () {
+    assert.throws(() => {
+      Access.authorize.invoke({
+        issuer: bob,
+        audience: service,
+        with: bob.did(),
+        nb: {
+          // @ts-expect-error
+          as: 'did:NOT_MAILTO:web3.storage:test',
+        },
+      })
+    }, /Expected a did:mailto: but got "did:NOT_MAILTO:web3.storage:test" instead/)
+  })
+})

--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -28,7 +28,7 @@ import { REQUEST_RETRIES } from './constants.js'
  * @returns {Promise<import('./types').CARLink>}
  */
 export async function add(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   car,
   options = {}
 ) {
@@ -42,7 +42,8 @@ export async function add(
       return await StoreCapabilities.add
         .invoke({
           issuer,
-          audience,
+          /* c8 ignore next */
+          audience: audience ?? servicePrincipal,
           with: resource,
           nb: { link, size: car.size },
           proofs,
@@ -120,7 +121,7 @@ export async function add(
  * @returns {Promise<import('./types').ListResponse<import('./types').StoreListResult>>}
  */
 export async function list(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   options = {}
 ) {
   /* c8 ignore next */
@@ -128,7 +129,8 @@ export async function list(
   const result = await StoreCapabilities.list
     .invoke({
       issuer,
-      audience,
+      /* c8 ignore next */
+      audience: audience ?? servicePrincipal,
       with: resource,
       proofs,
       nb: {
@@ -167,7 +169,7 @@ export async function list(
  * @param {import('./types').RequestOptions} [options]
  */
 export async function remove(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   link,
   options = {}
 ) {
@@ -176,7 +178,8 @@ export async function remove(
   const result = await StoreCapabilities.remove
     .invoke({
       issuer,
-      audience,
+      /* c8 ignore next */
+      audience: audience ?? servicePrincipal,
       with: resource,
       nb: { link },
       proofs,

--- a/packages/upload-client/src/upload.js
+++ b/packages/upload-client/src/upload.js
@@ -28,7 +28,7 @@ import { REQUEST_RETRIES } from './constants.js'
  * @returns {Promise<import('./types').UploadAddResponse>}
  */
 export async function add(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   root,
   shards,
   options = {}
@@ -40,7 +40,8 @@ export async function add(
       return await UploadCapabilities.add
         .invoke({
           issuer,
-          audience,
+          /* c8 ignore next */
+          audience: audience ?? servicePrincipal,
           with: resource,
           nb: { root, shards },
           proofs,
@@ -82,7 +83,7 @@ export async function add(
  * @returns {Promise<import('./types').ListResponse<import('./types').UploadListResult>>}
  */
 export async function list(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   options = {}
 ) {
   /* c8 ignore next */
@@ -91,7 +92,8 @@ export async function list(
   const result = await UploadCapabilities.list
     .invoke({
       issuer,
-      audience,
+      /* c8 ignore next */
+      audience: audience ?? servicePrincipal,
       with: resource,
       proofs,
       nb: {
@@ -130,7 +132,7 @@ export async function list(
  * @param {import('./types').RequestOptions} [options]
  */
 export async function remove(
-  { issuer, with: resource, proofs, audience = servicePrincipal },
+  { issuer, with: resource, proofs, audience },
   root,
   options = {}
 ) {
@@ -139,7 +141,8 @@ export async function remove(
   const result = await UploadCapabilities.remove
     .invoke({
       issuer,
-      audience,
+      /* c8 ignore next */
+      audience: audience ?? servicePrincipal,
       with: resource,
       nb: { root },
       proofs,

--- a/readme.md
+++ b/readme.md
@@ -74,9 +74,9 @@ The most important prefixes you should have in mind are:
 
 ### Access API
 
-There's 3 environments prodution, staging and dev. The URLs are:
+There's 3 environments production, staging and dev. The URLs are:
 
-- Prodution: https://access.web3.storage
+- Production: https://access.web3.storage
 - Staging: https://w3access-staging.protocol-labs.workers.dev
 - Dev: https://w3access-dev.protocol-labs.workers.dev
 
@@ -87,7 +87,7 @@ The history and the current deployed commits can be checked at https://github.co
 1. Each PR deploys to `dev`, we should add support for unique deployments and remove `dev` completely.
 2. Each Access API **Release** PR deploys to `staging` every time the CI runs for that PR.
    - Note: Any change to the folder `packages/access-api` will update the Access API release PR and trigger a new deployment to `staging`.
-3. After merging an Access API release PR to `main` CI will deploy to `prodution`.
+3. After merging an Access API release PR to `main` CI will deploy to `production`.
 
 #### Reverting a bad deployment
 


### PR DESCRIPTION
The email validation approval process is now split into two stages: a GET request with no side effects except to load a page, that then auto-submits a POST request to actually continue the flow.

## Summary of problem

This fixes the API so as to follow [proper HTTP semantics](https://github.com/web3-storage/w3protocol/issues/333#issuecomment-1380925535):

> The purpose of distinguishing between safe [i.e. like GET] and unsafe [like PUT/POST] methods is to allow automated retrieval processes (spiders) and cache performance optimization (pre-fetching) to work without fear of causing harm. In addition, it allows a user agent to apply appropriate constraints on the automated use of unsafe methods when processing potentially untrusted content.

That is, a `PUT` or `POST` (rather than a `GET`) **must** be the method used in order to do things like

* cause a message to be sent (forwarding a UCAN delegation via a separate connection's websocket)
* cause an untrusted keypair to be associated with a billable email address (which is the outcome of that forwarding, in practice!)

Fixing the HTTP semantics should address all of #348, and is the first step to addressing the security concerns in #333.

## Summary of solution

Clicking (or scanning/pre-fetching/previewing/etc.) the link in the email no longer finishes the validation process. Instead, it loads a (harmless to scan/pre-fetch/preview) landing page which simply says "Validating Email" while using JavaScript to auto-complete the process.

My preference would have been to move more of the approval process *out* of the email and *into* this landing page. (So rather than auto-approving, this landing page would contain details/context and force an informed clear "Yes, approve this new space" vs. "No, I didn't want this" decision.) However, the team preferred to keep\* all that in the initial email and requested that this fix be based on an auto-approval.

Given that preference, this patch is able to fix the core HTTP semantics very self-contained:

* no changes needed to the email templates (\* though still would be good to do)
* will not break any existing unexpired links at the moment it is deployed
* is essentially the exact same UX from a user's perspective (they might notice just a little extra blink)
* does degrade gracefully if user has JS disabled, and any non-browser clients could still trigger the `POST` ± just as easy as before
* no changes needed on the `w3ui` side for this part of the email validation improvements
