### PR TITLE
fix: inconsistent w3ui custom URL handling

### DIFF
--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -79,7 +79,7 @@ export class Agent {
    * @param {import('./types').AgentOptions} [options]
    */
   constructor(data, options = {}) {
-    this.url = options.connection?.url ?? options.url ?? new URL(HOST)
+    this.url = options.connection?.channel.url ?? options.url ?? new URL(HOST)
     this.connection =
       options.connection ??
       connection({

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -79,7 +79,7 @@ export class Agent {
    * @param {import('./types').AgentOptions} [options]
    */
   constructor(data, options = {}) {
-    this.url = options.url ?? new URL(HOST)
+    this.url = options.connection?.url ?? options.url ?? new URL(HOST)
     this.connection =
       options.connection ??
       connection({

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -10,6 +10,7 @@ import type {
   Resource,
   ResponseDecoder,
   ServiceMethod,
+  Transport,
   URI,
   InferInvokedCapability,
   CapabilityParser,
@@ -171,14 +172,18 @@ export interface SpaceMeta {
  * Agent class types
  */
 
-// w3ui's keyring providers pass custom URL via this object
-interface _AgentConnection extends ConnectionView<Service> {
+// the Agent does bypass the connection.channel to open its own Websocket —
+// it tries reusing the channel's own URL if it has one from e.g. HTTP.open
+interface _AgentChannnelWithWebsocketUrl extends Transport.Channel<Service> {
   url?: URL
+}
+interface _AgentConnectionWithWebsocketUrl extends ConnectionView<Service> {
+  readonly channel: _AgentChannnelWithWebsocketUrl // xref ucanto's ConnectionOptions<T>
 }
 
 export interface AgentOptions {
   url?: URL
-  connection?: _AgentConnection
+  connection?: _AgentConnectionWithWebsocketUrl
   servicePrincipal?: Principal
 }
 

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -171,9 +171,14 @@ export interface SpaceMeta {
  * Agent class types
  */
 
+// w3ui's keyring providers pass custom URL via this object
+interface _AgentConnection extends ConnectionView<Service> {
+  url?: URL
+}
+
 export interface AgentOptions {
   url?: URL
-  connection?: ConnectionView<Service>
+  connection?: _AgentConnection
   servicePrincipal?: Principal
 }
 


### PR DESCRIPTION
This is imo the cleanest way of resolving issue #344, where a custom server URL is used only for the individual HTTP requests and not for the corresponding WebSocket connection.

It took a while to decide the best place to fix this. For a little while, it seemed like the internals of `createAgent()` within  `@w3ui/keyring-core` needed to copy out the URL into its the top-level options. But ultimately I believe that would be an incorrect workaround!

The root cause is that `@web3-storage/access/agent` is pulling some tricks on its own that get it into trouble: instead of the `Agent` relying exclusive on its `this.connection` for all actual transport, it also cheats and creates its own `new Websocket(…)` on the side!

That extra websocket is the only reason the `Agent` instance keeps a copy of `this.url` at all — everything else goes through the proper `ConnectionView<Service>` abstraction. So I believe the `w3ui` code is fulfilling its side of the interface contract. Since it is the `Agent` that bypasses the abstraction, it is responsible to look for the raw URL inside of it.

This ends up being a relatively trivial code change, but did require some special (internal) extensions to the type definitions to support.