### PR TITLE
feat: rm upload-api-proxy ability to route to separate environment audiences

### DIFF
--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -30,7 +30,6 @@ export interface Env {
   DID: `did:web:${string}`
   // URLs to upload-api so we proxy invocations to it
   UPLOAD_API_URL: string
-  UPLOAD_API_URL_STAGING: string
   // secrets
   PRIVATE_KEY: string
   SENTRY_DSN: string
@@ -55,8 +54,7 @@ export interface RouteContext {
     validations: Validations
   }
   uploadApi: {
-    production?: URL
-    staging?: URL
+    ucanto?: { url: URL }
   }
 }
 

--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -5,7 +5,7 @@ import { Email } from './utils/email.js'
 import { Spaces } from './models/spaces.js'
 import { Validations } from './models/validations.js'
 import { loadConfig } from './config.js'
-import { Signer as EdSigner } from '@ucanto/principal/ed25519'
+import { ConnectionView, Signer as EdSigner } from '@ucanto/principal/ed25519'
 
 export {}
 
@@ -53,9 +53,7 @@ export interface RouteContext {
     spaces: Spaces
     validations: Validations
   }
-  uploadApi: {
-    ucanto?: { url: URL }
-  }
+  uploadApi: ConnectionView
 }
 
 export type Handler = _Handler<RouteContext>

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -58,7 +58,6 @@ export function loadConfig(env) {
     DID: DID.parse(vars.DID).did(),
 
     UPLOAD_API_URL: env.UPLOAD_API_URL,
-    UPLOAD_API_URL_STAGING: env.UPLOAD_API_URL_STAGING,
     // bindings
     METRICS:
       /** @type {import("./bindings").AnalyticsEngine} */ (

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -57,7 +57,7 @@ export function loadConfig(env) {
     PRIVATE_KEY: vars.PRIVATE_KEY,
     DID: DID.parse(vars.DID).did(),
 
-    UPLOAD_API_URL: env.UPLOAD_API_URL,
+    UPLOAD_API_URL: env.UPLOAD_API_URL || 'https://up.web3.storage/',
     // bindings
     METRICS:
       /** @type {import("./bindings").AnalyticsEngine} */ (

--- a/packages/access-api/src/service/upload-api-proxy.js
+++ b/packages/access-api/src/service/upload-api-proxy.js
@@ -59,10 +59,6 @@ const uploadApiEnvironments = {
     // until resolution of https://github.com/web3-storage/w3protocol/issues/363
     url: new URL('https://3bd9h7xn3j.execute-api.us-west-2.amazonaws.com/'),
   },
-  staging: {
-    audience: /** @type {const} */ ('did:web:staging.web3.storage'),
-    url: new URL('https://staging.up.web3.storage'),
-  },
 }
 
 /**
@@ -73,21 +69,16 @@ const uploadApiEnvironments = {
 /**
  * @param {object} options
  * @param {typeof globalThis.fetch} [options.fetch]
- * @param {object} options.uploadApi
- * @param {URL} [options.uploadApi.production]
- * @param {URL} [options.uploadApi.staging]
+ * @param {import('../bindings.js').RouteContext['uploadApi']} options.uploadApi
  */
 function getDefaultConnections(options) {
   const { fetch = globalThis.fetch.bind(globalThis), uploadApi } = options
   return {
     default: createUcantoHttpConnection({
+      // use production environment
       ...uploadApiEnvironments.production,
-      ...(uploadApi.production && { url: uploadApi.production }),
-      fetch,
-    }),
-    [uploadApiEnvironments.staging.audience]: createUcantoHttpConnection({
-      ...uploadApiEnvironments.staging,
-      url: uploadApi.staging ?? uploadApiEnvironments.staging.url,
+      // but override uploadApi.url from configuration, if provided
+      ...uploadApi.ucanto,
       fetch,
     }),
   }
@@ -99,9 +90,7 @@ function getDefaultConnections(options) {
  * @param {typeof globalThis.fetch} [options.fetch]
  * @param {{ default: Connection, [K: Ucanto.UCAN.DID]: Connection }} [options.connections]
  * @param {Record<Ucanto.UCAN.DID, URL>} [options.audienceToUrl]
- * @param {object} options.uploadApi
- * @param {URL} [options.uploadApi.production]
- * @param {URL} [options.uploadApi.staging]
+ * @param {import('../bindings.js').RouteContext['uploadApi']} options.uploadApi
  */
 export function createUploadProxy(options) {
   return createProxyService({
@@ -117,9 +106,7 @@ export function createUploadProxy(options) {
  * @param {typeof globalThis.fetch} [options.fetch]
  * @param {{ default: Connection, [K: Ucanto.UCAN.DID]: Connection }} [options.connections]
  * @param {Record<Ucanto.UCAN.DID, URL>} [options.audienceToUrl]
- * @param {object} options.uploadApi
- * @param {URL} [options.uploadApi.production]
- * @param {URL} [options.uploadApi.staging]
+ * @param {import('../bindings.js').RouteContext['uploadApi']} options.uploadApi
  */
 export function createStoreProxy(options) {
   return createProxyService({

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -6,6 +6,8 @@ import { loadConfig } from '../config.js'
 import { Spaces } from '../models/spaces.js'
 import { Validations } from '../models/validations.js'
 import { Email } from './email.js'
+import { createUploadApiConnection } from '../service/upload-api-proxy.js'
+import { DID } from '@ucanto/core'
 
 /**
  * Obtains a route context object.
@@ -55,10 +57,10 @@ export function getContext(request, env, ctx) {
       validations: new Validations(config.VALIDATIONS),
     },
     email: new Email({ token: config.POSTMARK_TOKEN }),
-    uploadApi: {
-      ucanto: config.UPLOAD_API_URL
-        ? { url: new URL(config.UPLOAD_API_URL) }
-        : undefined,
-    },
+    uploadApi: createUploadApiConnection({
+      audience: DID.parse(config.DID).did(),
+      url: new URL(config.UPLOAD_API_URL),
+      fetch: globalThis.fetch.bind(globalThis),
+    }),
   }
 }

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -56,11 +56,8 @@ export function getContext(request, env, ctx) {
     },
     email: new Email({ token: config.POSTMARK_TOKEN }),
     uploadApi: {
-      production: config.UPLOAD_API_URL
-        ? new URL(config.UPLOAD_API_URL)
-        : undefined,
-      staging: config.UPLOAD_API_URL_STAGING
-        ? new URL(config.UPLOAD_API_URL_STAGING)
+      ucanto: config.UPLOAD_API_URL
+        ? { url: new URL(config.UPLOAD_API_URL) }
         : undefined,
     },
   }

--- a/packages/access-api/test/helpers/context.js
+++ b/packages/access-api/test/helpers/context.js
@@ -34,7 +34,6 @@ function createBindings(env) {
     LOGTAIL_TOKEN: env.LOGTAIL_TOKEN || '',
     W3ACCESS_METRICS: createAnalyticsEngine(),
     UPLOAD_API_URL: env.UPLOAD_API_URL || '',
-    UPLOAD_API_URL_STAGING: env.UPLOAD_API_URL_STAGING || '',
   }
 }
 

--- a/packages/access-api/test/store-list.js
+++ b/packages/access-api/test/store-list.js
@@ -13,8 +13,7 @@ import {
 
 describe('proxy store/list invocations to upload-api', function () {
   for (const web3storageDid of /** @type {const} */ ([
-    'did:web:web3.storage',
-    'did:web:staging.web3.storage',
+    'did:web:test.web3.storage',
   ])) {
     it(`forwards invocations with aud=${web3storageDid}`, async function () {
       const mockUpstream = createMockUploadApiServer({
@@ -47,7 +46,6 @@ describe('proxy store/list invocations to upload-api', function () {
         // @ts-ignore
         PRIVATE_KEY: privateKeyFromEnv ?? process.env.PRIVATE_KEY,
         UPLOAD_API_URL: mockUpstreamUrl.toString(),
-        UPLOAD_API_URL_STAGING: mockUpstreamUrl.toString(),
       })
       const spaceCreation = await createSpace(
         issuer,

--- a/packages/access-api/wrangler.toml
+++ b/packages/access-api/wrangler.toml
@@ -60,7 +60,7 @@ unsafe = { bindings = [
 [env.staging]
 name = "w3access-staging"
 workers_dev = true
-vars = { ENV = "staging", DEBUG = "false", DID = "did:web:staging.web3.storage" }
+vars = { ENV = "staging", DEBUG = "false", DID = "did:web:staging.web3.storage", UPLOAD_API_URL = "https://staging.up.web3.storage" }
 build = { command = "scripts/cli.js build --env staging", watch_dir = "src" }
 kv_namespaces = [
     { binding = "SPACES", id = "b0e5ca990dda4e3784a1741dfa28a52e" },

--- a/packages/access-api/wrangler.toml
+++ b/packages/access-api/wrangler.toml
@@ -29,6 +29,7 @@ database_id = "7c676e0c-b9e7-4711-97c8-7b1c8eb229ae"
 ENV = "dev"
 DEBUG = "true"
 DID = "did:web:local.web3.storage"
+UPLOAD_API_URL = "https://up.web3.storage"
 
 [build]
 command = "scripts/cli.js build"
@@ -37,12 +38,11 @@ watch_dir = "src"
 [miniflare]
 d1_persist = ".wrangler/miniflare"
 
-
 # Dev
 [env.dev]
 name = "w3access-dev"
 workers_dev = true
-vars = { ENV = "dev", DEBUG = "false", DID = "did:web:dev.web3.storage" }
+vars = { ENV = "dev", DEBUG = "false", DID = "did:web:dev.web3.storage", UPLOAD_API_URL = "https://staging.up.web3.storage" }
 build = { command = "scripts/cli.js build --env dev", watch_dir = "src" }
 kv_namespaces = [
     { binding = "SPACES", id = "5697e95e1aaa436788e6d697fd3350be" },
@@ -90,3 +90,6 @@ d1_databases = [
 unsafe = { bindings = [
     { type = "analytics_engine", dataset = "W3ACCESS_METRICS", name = "W3ACCESS_METRICS" },
 ] }
+[env.production.vars]
+# production upload-api, but bypass up.web3.storage due to cloudflare dns issue https://github.com/web3-storage/w3protocol/issues/363#issuecomment-1410887488
+UPLOAD_API_URL = "https://3bd9h7xn3j.execute-api.us-west-2.amazonaws.com/"

--- a/packages/access-api/wrangler.toml
+++ b/packages/access-api/wrangler.toml
@@ -78,7 +78,6 @@ unsafe = { bindings = [
 [env.production]
 name = "w3access"
 routes = [{ pattern = "access.web3.storage", custom_domain = true }]
-vars = { ENV = "production", DEBUG = "false", DID = "did:web:web3.storage" }
 build = { command = "scripts/cli.js build --env production", watch_dir = "src" }
 kv_namespaces = [
     { binding = "SPACES", id = "5437954e8cfd4f7d98557132b0a2e93f" },
@@ -91,5 +90,8 @@ unsafe = { bindings = [
     { type = "analytics_engine", dataset = "W3ACCESS_METRICS", name = "W3ACCESS_METRICS" },
 ] }
 [env.production.vars]
-# production upload-api, but bypass up.web3.storage due to cloudflare dns issue https://github.com/web3-storage/w3protocol/issues/363#issuecomment-1410887488
+DEBUG = "false"
+DID = "did:web:web3.storage"
+ENV = "production"
+# production upload-api - bypass up.web3.storage due to cloudflare dns issue https://github.com/web3-storage/w3protocol/issues/363#issuecomment-1410887488
 UPLOAD_API_URL = "https://3bd9h7xn3j.execute-api.us-west-2.amazonaws.com/"


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/406
  * tl;dr remove some code/behavior that's not strictly needed and @hugomrdias asked me to remove