### PR TITLE
feat: define access/claim in @web3-storage/capabilities

### DIFF
--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -88,7 +88,8 @@
     "rules": {
       "unicorn/prefer-number-properties": "off",
       "unicorn/prefer-export-from": "off",
-      "unicorn/no-array-reduce": "off"
+      "unicorn/no-array-reduce": "off",
+      "jsdoc/no-undefined-types": "error"
     },
     "env": {
       "mocha": true

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -31,7 +31,6 @@ export const access = top.derive({
   to: capability({
     can: 'access/*',
     with: URI.match({ protocol: 'did:' }),
-    derives: equalWith,
   }),
   derives: equalWith,
 })

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -100,3 +100,11 @@ export const session = capability({
     key: DID.match({ method: 'key' }),
   },
 })
+
+export const claim = base.derive({
+  to: capability({
+    can: 'access/claim',
+    with: DID.match({ method: 'key' }).or(DID.match({ method: 'mailto' })),
+  }),
+  derives: equalWith,
+})

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -105,6 +105,7 @@ export const claim = base.derive({
   to: capability({
     can: 'access/claim',
     with: DID.match({ method: 'key' }).or(DID.match({ method: 'mailto' })),
+    derives: equalWith,
   }),
   derives: equalWith,
 })

--- a/packages/capabilities/test/capabilities/access.test.js
+++ b/packages/capabilities/test/capabilities/access.test.js
@@ -226,7 +226,7 @@ describe('access capabilities', function () {
 
   describe('access/claim', () => {
     // ensure we can use the capability to produce the invocations from the spec at https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md
-    it('can create delegations from spec', async () => {
+    it('can access delegations from spec', async () => {
       const audience = service.withDID('did:web:web3.storage')
       /**
        * @type {Array<(arg: { issuer: Ucanto.Signer<Ucanto.DID<'key'>>}) => Ucanto.IssuedInvocation<Ucanto.InferInvokedCapability<typeof Access.claim>>>}
@@ -264,6 +264,19 @@ describe('access capabilities', function () {
         )
         assert.deepEqual(result.capability.nb, {}, 'result has empty nb')
       }
+    })
+    it('cannot invoke when .with uses unexpected did method', async () => {
+      const issuer = bob.withDID('did:foo:bar')
+      assert.throws(
+        () =>
+          Access.claim.invoke({
+            issuer,
+            audience: service,
+            // @ts-ignore - expected complaint from compiler. We want to make sure there is an equivalent error at runtime
+            with: issuer.did(),
+          }),
+        `Invalid 'with'`
+      )
     })
   })
 })

--- a/packages/capabilities/test/capabilities/access.test.js
+++ b/packages/capabilities/test/capabilities/access.test.js
@@ -227,7 +227,7 @@ describe('access capabilities', function () {
 
   describe('access/claim', () => {
     // ensure we can use the capability to produce the invocations from the spec at https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md
-    it('can access delegations from spec', async () => {
+    it('can create/access delegations from spec', async () => {
       const audience = service.withDID('did:web:web3.storage')
       /**
        * @type {Array<(arg: { issuer: Ucanto.Signer<Ucanto.DID<'key'>>}) => Ucanto.IssuedInvocation<Ucanto.InferInvokedCapability<typeof Access.claim>>>}
@@ -308,6 +308,30 @@ describe('access capabilities', function () {
           e.message.includes('but got "did:foo:bar" instead')
         ),
         'a result.delegationErrors message mentions invalid with value'
+      )
+    })
+    it('does not authorize invocations whose .with is not an issuer in proofs', async () => {
+      const issuer = bob
+      const audience = service
+      const invocation = await Access.claim
+        .invoke({
+          issuer,
+          audience,
+          // note: this did is not same as issuer.did() so issuer has no proof that they can use this resource
+          with: alice.did(),
+        })
+        .delegate()
+      const result = await access(invocation, {
+        capability: Access.claim,
+        principal: Verifier,
+        authority: audience,
+      })
+      assert.ok(result.error, 'result of access(invocation) is an error')
+      assert.deepEqual(result.name, 'Unauthorized')
+      assert.ok(
+        result.failedProofs.find((e) => {
+          return /Capability (.+) is not authorized/.test(e.message)
+        })
       )
     })
   })

--- a/packages/capabilities/test/capabilities/access.test.js
+++ b/packages/capabilities/test/capabilities/access.test.js
@@ -239,56 +239,6 @@ describe('access capabilities', function () {
             with: issuer.did(),
           })
         },
-        // https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L185
-        ({ issuer }) => {
-          const account = issuer.withDID('did:mailto:web.mail:alice')
-          Access.claim.invoke({
-            issuer: account,
-            audience: ucanto.DID.parse('did:web:web3.storage'),
-            with: account.did(),
-            proofs: [
-              /*
-              // @TODO: include proof like this from spec text https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L194
-              {
-                "iss": "did:web:web3.storage",
-                "aud": "did:mailto:web.mail:alice",
-                "att": [
-                  {
-                    "with": "did:web:web3.storage",
-                    "can": "./update",
-                    "nb": { "key": "did:key:zAli" }
-                  }
-                ]
-              }
-              */
-            ],
-          })
-        },
-        // https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L257
-        ({ issuer }) => {
-          const account = issuer.withDID('did:mailto:gmail.com:bob')
-          Access.claim.invoke({
-            issuer: account,
-            audience: ucanto.DID.parse('did:web:web3.storage'),
-            with: account.did(),
-            proofs: [
-              /*
-              // @TODO: include proof like this from spec text https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L266
-              {
-                "iss": "did:web:web3.storage",
-                "aud": "did:mailto:gmail.com:bob",
-                "att": [
-                  {
-                    "with": "did:web:web3.storage",
-                    "can": "./update",
-                    "nb": { "key": "did:key:zBobAgent" }
-                  }
-                ]
-              }
-              */
-            ],
-          })
-        },
       ]
       for (const example of examples) {
         await example({ issuer: bob })

--- a/packages/capabilities/test/capabilities/access.test.js
+++ b/packages/capabilities/test/capabilities/access.test.js
@@ -3,6 +3,7 @@ import { access } from '@ucanto/validator'
 import { Verifier } from '@ucanto/principal/ed25519'
 import * as Access from '../../src/access.js'
 import { alice, bob, service, mallory } from '../helpers/fixtures.js'
+import * as ucanto from '@ucanto/core'
 
 describe('access capabilities', function () {
   it('should self issue', async function () {
@@ -221,5 +222,77 @@ describe('access capabilities', function () {
         },
       })
     }, /Expected a did:mailto: but got "did:NOT_MAILTO:web3.storage:test" instead/)
+  })
+
+  describe('access/claim', () => {
+    // ensure we can use the capability to produce the invocations from the spec at https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md
+    it('can create delegations from spec', async () => {
+      /**
+       * @type {Array<(arg: { issuer: import('@ucanto/principal').ed25519.Signer.EdSigner }) => void|Promise<void>>}
+       */
+      const examples = [
+        // https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md#accessclaim
+        ({ issuer }) => {
+          Access.claim.invoke({
+            issuer,
+            audience: ucanto.DID.parse('did:web:web3.storage'),
+            with: issuer.did(),
+          })
+        },
+        // https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L185
+        ({ issuer }) => {
+          const account = issuer.withDID('did:mailto:web.mail:alice')
+          Access.claim.invoke({
+            issuer: account,
+            audience: ucanto.DID.parse('did:web:web3.storage'),
+            with: account.did(),
+            proofs: [
+              /*
+              // @TODO: include proof like this from spec text https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L194
+              {
+                "iss": "did:web:web3.storage",
+                "aud": "did:mailto:web.mail:alice",
+                "att": [
+                  {
+                    "with": "did:web:web3.storage",
+                    "can": "./update",
+                    "nb": { "key": "did:key:zAli" }
+                  }
+                ]
+              }
+              */
+            ],
+          })
+        },
+        // https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L257
+        ({ issuer }) => {
+          const account = issuer.withDID('did:mailto:gmail.com:bob')
+          Access.claim.invoke({
+            issuer: account,
+            audience: ucanto.DID.parse('did:web:web3.storage'),
+            with: account.did(),
+            proofs: [
+              /*
+              // @TODO: include proof like this from spec text https://github.com/web3-storage/specs/blob/576b988fb7cfa60049611963179277c420605842/w3-access.md?plain=1#L266
+              {
+                "iss": "did:web:web3.storage",
+                "aud": "did:mailto:gmail.com:bob",
+                "att": [
+                  {
+                    "with": "did:web:web3.storage",
+                    "can": "./update",
+                    "nb": { "key": "did:key:zBobAgent" }
+                  }
+                ]
+              }
+              */
+            ],
+          })
+        },
+      ]
+      for (const example of examples) {
+        await example({ issuer: bob })
+      }
+    })
   })
 })


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/408

Unblocks:
* people importing a canonical CapabilityParser for `access/claim`
* adding advanced tests e.g. by [reverting this and finishing the TODOs](https://github.com/web3-storage/w3protocol/pull/409/commits/fd0b56ff7459d0178e3b9daa64a59bf1bcd9a463)
  * these involve `can=./update` abilities, so may make most sense to add after https://github.com/web3-storage/w3protocol/pull/392 which defines tools for them