### PR TITLE
chore: add documentation for paging caveats

### DIFF
--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -200,8 +200,6 @@ The `with` field of the invocation must be set to the DID of the memory space to
 `cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `store/list`
 `size` can be set to change the number of items returned by an `store/list` invocation
 
-Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
-
 | field       | value                    | required? | context                                                         |
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
@@ -288,8 +286,6 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 `cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `upload/list`
 `size` can be set to change the number of items returned by an `upload/list` invocation
-
-Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
 
 | field       | value                    | required? | context                                                         |
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -291,6 +291,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
+
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -197,7 +197,15 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-None currently, but this is expected to change once pagination is fully implemented.
+`cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `store/list`
+`size` can be set to change the number of items returned by an `store/list` invocation
+
+Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
+
+| field       | value                    | required? | context                                                         |
+| ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
+| `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
+| `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
 
 ## `upload/` namespace
 
@@ -278,8 +286,15 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-None currently, but this is expected to change once pagination is fully implemented.
+`cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `upload/list`
+`size` can be set to change the number of items returned by an `upload/list` invocation
 
+Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
+
+| field       | value                    | required? | context                                                         |
+| ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
+| `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
+| `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.


### PR DESCRIPTION
`store/list` and `upload/list` both accept paging parameters - document them.