### PR TITLE
feat: add `pre` caveat to `store/list` and `upload/list`

### DIFF
--- a/packages/capabilities/src/store.js
+++ b/packages/capabilities/src/store.js
@@ -153,7 +153,7 @@ export const list = base.derive({
       /**
        * If true, return page of results preceding cursor. Defaults to false.
        */
-      prev: Schema.boolean().optional(),
+      pre: Schema.boolean().optional(),
     },
     derives: (claimed, delegated) => {
       if (claimed.with !== delegated.with) {

--- a/packages/capabilities/src/store.js
+++ b/packages/capabilities/src/store.js
@@ -150,6 +150,10 @@ export const list = base.derive({
        * Maximum number of items per page.
        */
       size: Schema.integer().optional(),
+      /**
+       * If true, return page of results preceding cursor. Defaults to false.
+       */
+      prev: Schema.boolean().optional(),
     },
     derives: (claimed, delegated) => {
       if (claimed.with !== delegated.with) {

--- a/packages/capabilities/src/upload.js
+++ b/packages/capabilities/src/upload.js
@@ -150,6 +150,10 @@ export const list = base.derive({
        * Maximum number of items per page.
        */
       size: Schema.integer().optional(),
+      /**
+       * If true, return page of results preceding cursor. Defaults to false.
+       */
+      prev: Schema.boolean().optional(),
     },
   }),
   /**

--- a/packages/capabilities/src/upload.js
+++ b/packages/capabilities/src/upload.js
@@ -153,7 +153,7 @@ export const list = base.derive({
       /**
        * If true, return page of results preceding cursor. Defaults to false.
        */
-      prev: Schema.boolean().optional(),
+      pre: Schema.boolean().optional(),
     },
   }),
   /**

--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -136,7 +136,7 @@ export async function list(
       nb: {
         cursor: options.cursor,
         size: options.size,
-        prev: options.prev,
+        pre: options.pre,
       },
     })
     .execute(conn)

--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -136,6 +136,7 @@ export async function list(
       nb: {
         cursor: options.cursor,
         size: options.size,
+        prev: options.prev,
       },
     })
     .execute(conn)

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -177,7 +177,7 @@ export interface Pageable {
   /**
    * If true, return page of results preceding cursor. Defaults to false.
    */
-  prev?: boolean
+  pre?: boolean
 }
 
 export interface RequestOptions extends Retryable, Abortable, Connectable {}

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -174,6 +174,10 @@ export interface Pageable {
    * Maximum number of items to return.
    */
   size?: number
+  /**
+   * If true, return page of results preceding cursor. Defaults to false.
+   */
+  prev?: boolean
 }
 
 export interface RequestOptions extends Retryable, Abortable, Connectable {}

--- a/packages/upload-client/src/upload.js
+++ b/packages/upload-client/src/upload.js
@@ -99,7 +99,7 @@ export async function list(
       nb: {
         cursor: options.cursor,
         size: options.size,
-        prev: options.prev,
+        pre: options.pre,
       },
     })
     .execute(conn)

--- a/packages/upload-client/src/upload.js
+++ b/packages/upload-client/src/upload.js
@@ -99,6 +99,7 @@ export async function list(
       nb: {
         cursor: options.cursor,
         size: options.size,
+        prev: options.prev,
       },
     })
     .execute(conn)

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -199,13 +199,13 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 `cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `store/list`
 `size` can be set to change the number of items returned by an `store/list` invocation
-`prev` can be set to `true` to return the page of results preceding `cursor` rather than the results after `cursor`. Defaults to `false`.
+`pre` can be set to `true` to return the page of results preceding `cursor` rather than the results after `cursor`. Defaults to `false`.
 
 | field       | value                    | required? | context                                                         |
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.prev`   | boolean                  | ❌         | If true, return previous page of results                        |
+| `nb.pre`    | boolean                  | ❌         | If true, return previous page of results                        |
 
 ## `upload/` namespace
 
@@ -288,7 +288,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 `cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `upload/list`
 `size` can be set to change the number of items returned by an `upload/list` invocation
-`prev` can be set to `true` to return the page of results preceding `cursor` rather than the results after `cursor`. Defaults to `false`.
+`pre` can be set to `true` to return the page of results preceding `cursor` rather than the results after `cursor`. Defaults to `false`.
 
 | field       | value                    | required? | context                                                         |
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
@@ -299,7 +299,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.prev`   | boolean                  | ❌         | If true, return previous page of results                        |
+| `nb.pre`    | boolean                  | ❌         | If true, return previous page of results                        |
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -299,7 +299,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.pre`    | boolean                  | ❌         | If true, return previous page of results                        |
+| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceeding the cursor |
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -199,6 +199,8 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 `cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `store/list`
 `size` can be set to change the number of items returned by an `store/list` invocation
+`prev` can be set to `true` to return the page of results preceding `cursor` rather than the results after `cursor`. Defaults to `false`.
+
 
 Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
 
@@ -206,6 +208,7 @@ Taken together, the CARs in the `shards` array should contain all the blocks in 
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
+| `nb.prev`   | boolean                  | ❌         | If true, return previous page of results                        |
 
 ## `upload/` namespace
 
@@ -288,6 +291,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 `cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `upload/list`
 `size` can be set to change the number of items returned by an `upload/list` invocation
+`prev` can be set to `true` to return the page of results preceding `cursor` rather than the results after `cursor`. Defaults to `false`.
 
 Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
 
@@ -295,6 +299,7 @@ Taken together, the CARs in the `shards` array should contain all the blocks in 
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
+| `nb.prev`   | boolean                  | ❌         | If true, return previous page of results                        |
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -205,7 +205,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.pre`    | boolean                  | ❌         | If true, return previous page of results                        |
+| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceeding the cursor |
 
 ## `upload/` namespace
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -197,7 +197,15 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-None currently, but this is expected to change once pagination is fully implemented.
+`cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `store/list`
+`size` can be set to change the number of items returned by an `store/list` invocation
+
+Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
+
+| field       | value                    | required? | context                                                         |
+| ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
+| `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
+| `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
 
 ## `upload/` namespace
 
@@ -278,8 +286,15 @@ The `with` field of the invocation must be set to the DID of the memory space to
 
 #### Caveats
 
-None currently, but this is expected to change once pagination is fully implemented.
+`cursor` can be set to start listing from an item in the middle of the list. Its value should be a `cursor` returned by a previous invocation of `upload/list`
+`size` can be set to change the number of items returned by an `upload/list` invocation
 
+Taken together, the CARs in the `shards` array should contain all the blocks in the DAG identified by the `root` CID.
+
+| field       | value                    | required? | context                                                         |
+| ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
+| `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
+| `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.


### PR DESCRIPTION
Per https://github.com/web3-storage/w3ui/issues/143 we'd like to give clients a way to get the previous page of results rather than the next page.

This change introduces a `pre` caveat which, when set to true, will return the page of results preceding `cursor`.

I considered calling this `reverse` or `rev` but I think that implies that results will be returned sorted in reverse, which is not the intent.