### PR TITLE
chore: fix merge gone bad

### DIFF
--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -205,7 +205,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceeding the cursor |
+| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceding the cursor |
 
 ## `upload/` namespace
 
@@ -294,7 +294,7 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceeding the cursor       |
+| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceding the cursor       |
 
 ## `voucher/` namespace
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -294,12 +294,8 @@ The `with` field of the invocation must be set to the DID of the memory space to
 | ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
 | `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
 | `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
+| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceeding the cursor       |
 
-| field       | value                    | required? | context                                                         |
-| ----------- | ------------------------ | --------- | --------------------------------------------------------------- |
-| `nb.cursor` | string                   | ❌         | A cursor returned by a previous invocation                      |
-| `nb.size`   | integer                  | ❌         | The maximum number of results to return                         |
-| `nb.pre`    | boolean                  | ❌         | If true, return the page of results preceeding the cursor |
 ## `voucher/` namespace
 
 TODO: more voucher docs when implementation details settle down a bit.


### PR DESCRIPTION
it looks like I fumbled a merge somewhere and we have duplicate caveat tables under `upload/list` - fix that

plus, fix spelling error - s/preceeding/preceding/