### PR TITLE
fix: look for URL in channel before falling back to default

### DIFF
--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -29,6 +29,10 @@ const HOST = 'https://access.web3.storage'
 const PRINCIPAL = DID.parse('did:web:web3.storage')
 
 /**
+ * @typedef {import('./types').Service} Service
+ */
+
+/**
  * Creates a Ucanto connection for the w3access API
  *
  * Usage:
@@ -37,7 +41,6 @@ const PRINCIPAL = DID.parse('did:web:web3.storage')
  * import { connection } from '@web3-storage/access/agent'
  * ```
  *
- * @template {import('./types').Service} Service
  * @template {Ucanto.DID} T - DID method
  * @param {object} [options]
  * @param {Ucanto.Principal<T>} [options.principal] - w3access API Principal
@@ -79,7 +82,9 @@ export class Agent {
    * @param {import('./types').AgentOptions} [options]
    */
   constructor(data, options = {}) {
-    this.url = options.url ?? new URL(HOST)
+    /** @type { Client.Channel<Service> & { url?: URL } | undefined } */
+    const channel = options.connection?.channel
+    this.url = options.url ?? channel?.url ?? new URL(HOST)
     this.connection =
       options.connection ??
       connection({


### PR DESCRIPTION
This fixes https://github.com/web3-storage/w3protocol/issues/344 and makes it possible to connect to staging services with w3ui.

This PR obsoletes https://github.com/web3-storage/w3protocol/pull/404 per @alanshaw's suggestion in https://github.com/web3-storage/w3protocol/pull/404#issuecomment-1437391750 based on reasoning in https://github.com/web3-storage/ucanto/pull/214#issuecomment-1437271520 which points out that some sort of conditional or casting is probably unavoidable here.

My solution casts the channel to have an optional `url` field and looks in that field for a URL before falling back to the default `HOST`.

Have tested this locally with w3ui and verified it makes it possible to connect to staging services from w3ui - huzzah!