### PR TITLE
feat!: rename startCursor and endCursor to before and after

### DIFF
--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -66,10 +66,9 @@ export interface UploadAddResponse {
 export interface UploadRemoveResponse extends UploadAddResponse {}
 
 export interface ListResponse<R> {
-  // cursor is deprecated in favor of endCursor, which should always be exactly the same value
   cursor?: string
-  startCursor?: string
-  endCursor?: string
+  before?: string
+  after?: string
   size: number
   results: R[]
 }


### PR DESCRIPTION
Per the reasoning and change in https://github.com/web3-storage/w3infra/pull/148