### PR TITLE
feat: `access/claim` only claims delegations with the correct audience

### DIFF
--- a/packages/access-api/package.json
+++ b/packages/access-api/package.json
@@ -22,6 +22,7 @@
     "@ucanto/principal": "^4.2.3",
     "@ucanto/server": "^4.2.3",
     "@ucanto/transport": "^4.2.3",
+    "@ucanto/validator": "^4.2.3",
     "@web3-storage/access": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/worker-utils": "0.4.3-dev",

--- a/packages/access-api/src/models/delegations.js
+++ b/packages/access-api/src/models/delegations.js
@@ -48,10 +48,10 @@ export class DbDelegationsStorage {
   /**
    * @param {import('../types/delegations').Query} query
    */
-  async find(query) {
-    const rows = [...(await selectByAudience(this.#db, query.audience))]
-    const delegations = rows.map((r) => rowToDelegation(r))
-    return delegations
+  async *find(query) {
+    for await (const row of await selectByAudience(this.#db, query.audience)) {
+      yield rowToDelegation(row)
+    }
   }
 
   /**

--- a/packages/access-api/src/models/delegations.js
+++ b/packages/access-api/src/models/delegations.js
@@ -46,6 +46,15 @@ export class DbDelegationsStorage {
   }
 
   /**
+   * @param {import('../types/delegations').Query} query
+   */
+  async find(query) {
+    const rows = [...(await selectByAudience(this.#db, query.audience))]
+    const delegations = rows.map((r) => rowToDelegation(r))
+    return delegations
+  }
+
+  /**
    * store items
    *
    * @param  {Array<Ucanto.Delegation>} delegations
@@ -111,4 +120,16 @@ function createDelegationRowUpdate(d) {
     issuer: d.issuer.did(),
     bytes: delegationsToBytes([d]),
   }
+}
+
+/**
+ * @param {DelegationsDatabase} db
+ * @param {Ucanto.DID<'key'>} audience
+ */
+async function selectByAudience(db, audience) {
+  return await db
+    .selectFrom('delegations')
+    .selectAll()
+    .where('delegations.audience', '=', audience)
+    .execute()
 }

--- a/packages/access-api/src/service/delegations.js
+++ b/packages/access-api/src/service/delegations.js
@@ -17,6 +17,14 @@ export function createDelegationsStorage(delegations = []) {
   async function count() {
     return BigInt(delegations.length)
   }
+  /** @type {import("../types/delegations").DelegationsStorage['find']} */
+  async function* find(query) {
+    for (const d of delegations) {
+      if (d.audience.did() === query.audience) {
+        yield d
+      }
+    }
+  }
   /** @type {import("../types/delegations").DelegationsStorage['putMany']} */
   async function putMany(...args) {
     return delegations.push(...args)
@@ -25,6 +33,7 @@ export function createDelegationsStorage(delegations = []) {
   const storage = {
     [Symbol.asyncIterator]: asyncIterator,
     count,
+    find,
     putMany,
   }
   return storage

--- a/packages/access-api/src/service/delegations.js
+++ b/packages/access-api/src/service/delegations.js
@@ -1,25 +1,32 @@
 import * as Ucanto from '@ucanto/interface'
 
+// without this alias, eslint jsdoc/check-types will complain below
+/* eslint-disable jsdoc/check-types */
+/**
+ * @typedef {typeof Symbol.iterator} SymbolIterator
+ */
+/* eslint-enable jsdoc/check-types */
+
 /**
  * DelegationsStorage that stores in-memory.
  *
- * @param {Array<Ucanto.Delegation>} delegations
+ * @param {Pick<Array<Ucanto.Delegation>, 'length' | 'push' | SymbolIterator>} storage
  * @returns {import("../types/delegations").DelegationsStorage}
  */
-export function createDelegationsStorage(delegations = []) {
+export function createDelegationsStorage(storage = []) {
   /** @type {import("../types/delegations").DelegationsStorage[typeof Symbol.asyncIterator]} */
   async function* asyncIterator() {
-    for (const delegation of delegations) {
+    for (const delegation of storage) {
       yield delegation
     }
   }
   /** @type {import("../types/delegations").DelegationsStorage['count']} */
   async function count() {
-    return BigInt(delegations.length)
+    return BigInt(storage.length)
   }
   /** @type {import("../types/delegations").DelegationsStorage['find']} */
   async function* find(query) {
-    for (const d of delegations) {
+    for (const d of storage) {
       if (d.audience.did() === query.audience) {
         yield d
       }
@@ -27,16 +34,16 @@ export function createDelegationsStorage(delegations = []) {
   }
   /** @type {import("../types/delegations").DelegationsStorage['putMany']} */
   async function putMany(...args) {
-    return delegations.push(...args)
+    return storage.push(...args)
   }
   /** @type {import('../types/delegations').DelegationsStorage} */
-  const storage = {
+  const delegations = {
     [Symbol.asyncIterator]: asyncIterator,
     count,
     find,
     putMany,
   }
-  return storage
+  return delegations
 }
 
 /**

--- a/packages/access-api/src/types/delegations.ts
+++ b/packages/access-api/src/types/delegations.ts
@@ -1,5 +1,10 @@
 import * as Ucanto from '@ucanto/interface'
 
+interface ByAudience {
+  audience: Ucanto.DID<'key'>
+}
+export type Query = ByAudience
+
 export interface DelegationsStorage<
   Cap extends Ucanto.Capability = Ucanto.Capability
 > {
@@ -23,4 +28,11 @@ export interface DelegationsStorage<
   [Symbol.asyncIterator]: () => AsyncIterableIterator<
     Ucanto.Delegation<Ucanto.Tuple<Cap>>
   >
+
+  /**
+   * find all items that match the query
+   */
+  find: (
+    query: Query
+  ) => Promise<Iterable<Ucanto.Delegation<Ucanto.Tuple<Cap>>>>
 }

--- a/packages/access-api/src/types/delegations.ts
+++ b/packages/access-api/src/types/delegations.ts
@@ -32,7 +32,5 @@ export interface DelegationsStorage<
   /**
    * find all items that match the query
    */
-  find: (
-    query: Query
-  ) => Promise<Iterable<Ucanto.Delegation<Ucanto.Tuple<Cap>>>>
+  find: (query: Query) => AsyncIterable<Ucanto.Delegation<Ucanto.Tuple<Cap>>>
 }

--- a/packages/access-api/test/access-delegate.test.js
+++ b/packages/access-api/test/access-delegate.test.js
@@ -14,6 +14,7 @@ import {
 import { createD1Database } from '../src/utils/d1.js'
 import { DbDelegationsStorage } from '../src/models/delegations.js'
 import { Voucher } from '@web3-storage/capabilities'
+import * as delegationsResponse from '../src/utils/delegations-response.js'
 
 /**
  * Run the same tests against several variants of access/delegate handlers.
@@ -523,20 +524,19 @@ async function testCanDelegateThenClaim(invoke, issuer, audience) {
   const { claim } = setup
   const claimResult = await invoke(claim)
   assertNotError(claimResult)
-
-  // const claimedDelegations = [
-  //   ...delegationsResponse.decode(
-  //     /** @type {import('../src/service/access-claim.js').AccessClaimSuccess} */ (
-  //       claimResult
-  //     ).delegations
-  //   ),
-  // ]
-  // const { delegations } = setup
-  // assert.deepEqual(
-  //   claimedDelegations,
-  //   delegations,
-  //   'claimed all delegated delegations'
-  // )
+  const claimedDelegations = [
+    ...delegationsResponse.decode(
+      /** @type {import('../src/service/access-claim.js').AccessClaimSuccess} */ (
+        claimResult
+      ).delegations
+    ),
+  ]
+  const { delegations } = setup
+  assert.deepEqual(
+    claimedDelegations,
+    delegations,
+    'claimed all delegated delegations'
+  )
 }
 
 /**
@@ -574,13 +574,12 @@ function warnOnErrorResult(
  */
 async function setupDelegateThenClaim(invoker, audience) {
   const alice = await principal.ed25519.generate()
-  const bob = await principal.ed25519.generate()
-  const aliceSaysBobCanStoreAllWithAlice = await ucanto.delegate({
+  const aliceSaysInvokerCanStoreAllWithAlice = await ucanto.delegate({
     issuer: alice,
-    audience: bob,
+    audience: invoker,
     capabilities: [{ can: 'store/*', with: alice.did() }],
   })
-  const delegations = [aliceSaysBobCanStoreAllWithAlice]
+  const delegations = [aliceSaysInvokerCanStoreAllWithAlice]
   // invocation of access/delegate
   const delegate = await Access.delegate
     .invoke({
@@ -588,15 +587,13 @@ async function setupDelegateThenClaim(invoker, audience) {
       audience,
       with: invoker.did(),
       nb: {
-        delegations: {
-          notACid: aliceSaysBobCanStoreAllWithAlice.cid,
-        },
+        delegations: toDelegationsDict(delegations),
       },
-      proofs: [aliceSaysBobCanStoreAllWithAlice],
+      proofs: delegations,
     })
     .delegate()
   // invocation of access/claim that should claim the delegations
-  // claim as bob, since bob is the audience of `aliceSaysBobCanStoreAllWithAlice`
+  // claim as invoker, since invoker is the audience of `aliceSaysInvokerCanStoreAllWithAlice`
   const claim = await Access.claim
     .invoke({
       issuer: invoker,

--- a/packages/access-api/test/access-delegate.test.js
+++ b/packages/access-api/test/access-delegate.test.js
@@ -519,12 +519,10 @@ async function testCanDelegateThenClaim(invoke, issuer, audience) {
     'result of access/delegate is not an error'
   )
 
-  // @todo uncomment the following assertions after further work on access/claim in https://github.com/web3-storage/w3protocol/issues/394
-  // it passed before, but not after https://github.com/web3-storage/w3protocol/pull/427#discussion_r1115842300
-
-  // // delegate succeeded, now try to claim it
-  // const claimResult = await invoke(claim)
-  // assertNotError(claimResult)
+  // delegate succeeded, now try to claim it
+  const { claim } = setup
+  const claimResult = await invoke(claim)
+  assertNotError(claimResult)
 
   // const claimedDelegations = [
   //   ...delegationsResponse.decode(

--- a/packages/access-api/test/delegations-storage.test.js
+++ b/packages/access-api/test/delegations-storage.test.js
@@ -3,6 +3,9 @@ import { DbDelegationsStorage } from '../src/models/delegations.js'
 import { createD1Database } from '../src/utils/d1.js'
 import * as assert from 'node:assert'
 import { createSampleDelegation } from '../src/utils/ucan.js'
+import * as principal from '@ucanto/principal'
+import * as Ucanto from '@ucanto/interface'
+import * as ucanto from '@ucanto/core'
 
 describe('DbDelegationsStorage', () => {
   it('should persist delegations', async () => {
@@ -15,4 +18,44 @@ describe('DbDelegationsStorage', () => {
     await storage.putMany(...delegations)
     assert.deepEqual(await storage.count(), delegations.length)
   })
+
+  it('can retrieve delegations by audience', async () => {
+    const { issuer, d1 } = await context()
+    const alice = await principal.ed25519.generate()
+    const bob = await principal.ed25519.generate()
+    const delegations = new DbDelegationsStorage(createD1Database(d1))
+    const delegationA = await createDelegation({ issuer, audience: alice })
+    const delegationB = await createDelegation({ issuer, audience: bob })
+    await delegations.putMany(delegationA, delegationB)
+
+    const aliceDelegations = await delegations.find({ audience: alice.did() })
+    assert.deepEqual(aliceDelegations.length, 1)
+    const bobDelegations = await delegations.find({ audience: bob.did() })
+    assert.deepEqual(bobDelegations.length, 1)
+  })
 })
+
+/**
+ * @param {object} [opts]
+ * @param {Ucanto.Signer<Ucanto.DID>} [opts.issuer]
+ * @param {Ucanto.Principal} [opts.audience]
+ * @param {Ucanto.Capabilities} [opts.capabilities]
+ * @returns {Promise<Ucanto.Delegation>}
+ */
+async function createDelegation(opts = {}) {
+  const {
+    issuer = await principal.ed25519.generate(),
+    audience = issuer,
+    capabilities = [
+      {
+        can: 'test/*',
+        with: issuer.did(),
+      },
+    ],
+  } = opts
+  return await ucanto.delegate({
+    issuer,
+    audience,
+    capabilities,
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ importers:
       '@ucanto/principal': ^4.2.3
       '@ucanto/server': ^4.2.3
       '@ucanto/transport': ^4.2.3
+      '@ucanto/validator': ^4.2.3
       '@web3-storage/access': workspace:^
       '@web3-storage/capabilities': workspace:^
       '@web3-storage/worker-utils': 0.4.3-dev
@@ -80,6 +81,7 @@ importers:
       '@ucanto/principal': 4.2.3
       '@ucanto/server': 4.2.3
       '@ucanto/transport': 4.2.3
+      '@ucanto/validator': 4.2.3
       '@web3-storage/access': link:../access-client
       '@web3-storage/capabilities': link:../capabilities
       '@web3-storage/worker-utils': 0.4.3-dev


### PR DESCRIPTION
Note:
* this PR targets https://github.com/web3-storage/w3protocol/tree/1675728220-handle-access-delegate

Motivation:
* this patch has things that are more related to #394 . They don't need to be a part of #427, which is motivated by #425. I don't mind putting them alltogether, but I'm holding these out while iterating on #427 based on review