### PR TITLE
feat: access/authorize confirmation email click results in a delegation back to the issuer did:key so that access/claim works

### DIFF
--- a/packages/access-api/src/models/delegations.js
+++ b/packages/access-api/src/models/delegations.js
@@ -124,7 +124,7 @@ function createDelegationRowUpdate(d) {
 
 /**
  * @param {DelegationsDatabase} db
- * @param {Ucanto.DID<'key'>} audience
+ * @param {Ucanto.DID} audience
  */
 async function selectByAudience(db, audience) {
   return await db

--- a/packages/access-api/src/routes/validate-email.js
+++ b/packages/access-api/src/routes/validate-email.js
@@ -149,7 +149,7 @@ async function session(req, env) {
         `unable to validate access session: ${accessSessionResult.error}`
       )
     }
-    const account = { did: () => accessSessionResult.audience.did() }
+    const account = accessSessionResult.audience
     const agentPubkey = accessSessionResult.capability.nb.key
     const wrappedKeyCanAsignForAccount = await ucanto.delegate({
       issuer: env.signer,

--- a/packages/access-api/src/routes/validate-email.js
+++ b/packages/access-api/src/routes/validate-email.js
@@ -1,8 +1,5 @@
 /* eslint-disable no-unused-vars */
-import {
-  delegationsToBytes,
-  stringToDelegation,
-} from '@web3-storage/access/encoding'
+import { stringToDelegation } from '@web3-storage/access/encoding'
 import * as Access from '@web3-storage/capabilities/access'
 import QRCode from 'qrcode'
 import { toEmail } from '../utils/did-mailto.js'
@@ -219,7 +216,7 @@ async function session(req, env) {
           can: 'ucan/attest',
           with: env.signer.did(),
           nb: {
-            proof: delegationsToBytes([delegationAccountToKey]),
+            proof: delegationAccountToKey.cid,
           },
         },
       ],

--- a/packages/access-api/src/routes/validate-email.js
+++ b/packages/access-api/src/routes/validate-email.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { stringToDelegation } from '@web3-storage/access/encoding'
+import * as Access from '@web3-storage/capabilities/access'
 import QRCode from 'qrcode'
 import { toEmail } from '../utils/did-mailto.js'
 import {
@@ -8,6 +9,9 @@ import {
   ValidateEmailError,
   PendingValidateEmail,
 } from '../utils/html.js'
+import * as ucanto from '@ucanto/core'
+import * as validator from '@ucanto/validator'
+import { Verifier } from '@ucanto/principal/ed25519'
 
 /**
  * @param {import('@web3-storage/worker-utils/router').ParsedRequest} req
@@ -134,6 +138,38 @@ async function session(req, env) {
     req.query.ucan,
     delegation.capabilities[0].nb.key
   )
+  if (req.method.toLowerCase() === 'post') {
+    const accessSessionResult = await validator.access(delegation, {
+      capability: Access.session,
+      principal: Verifier,
+      authority: env.signer,
+    })
+    if (accessSessionResult.error) {
+      throw new Error(
+        `unable to validate access session: ${accessSessionResult.error}`
+      )
+    }
+    // generate a delegation to the key that we can save in
+    // models.delegations to be found by subsequent access/claim
+    // invocations invoked by the did:key
+    const delegateToKey = await ucanto.delegate({
+      issuer: env.signer,
+      audience: {
+        did() {
+          return accessSessionResult.capability.nb.key
+        },
+      },
+      proofs: [delegation],
+      capabilities: [
+        {
+          can: './update',
+          with: env.signer.did(),
+          nb: accessSessionResult.capability.nb,
+        },
+      ],
+    })
+    await env.models.delegations.putMany(delegateToKey)
+  }
 
   try {
     return new HtmlResponse(

--- a/packages/access-api/src/service/access-claim.js
+++ b/packages/access-api/src/service/access-claim.js
@@ -1,7 +1,6 @@
 import * as Server from '@ucanto/server'
 import { claim } from '@web3-storage/capabilities/access'
 import * as Ucanto from '@ucanto/interface'
-import * as validator from '@ucanto/validator'
 import * as delegationsResponse from '../utils/delegations-response.js'
 import { collect } from 'streaming-iterables'
 
@@ -41,9 +40,6 @@ export function createAccessClaimHandler({ delegations }) {
   /** @type {AccessClaimHandler} */
   return async (invocation) => {
     const claimedAudience = invocation.capabilities[0].with
-    if (validator.DID.match({ method: 'mailto' }).is(claimedAudience)) {
-      throw new Error(`did:mailto not supported`)
-    }
     const claimed = await collect(
       delegations.find({ audience: claimedAudience })
     )

--- a/packages/access-api/src/service/voucher-claim.js
+++ b/packages/access-api/src/service/voucher-claim.js
@@ -46,7 +46,5 @@ export function voucherClaimProvider(ctx) {
       to: capability.nb.identity.replace('mailto:', ''),
       url,
     })
-
-    return {}
   })
 }

--- a/packages/access-api/src/service/voucher-claim.js
+++ b/packages/access-api/src/service/voucher-claim.js
@@ -46,5 +46,7 @@ export function voucherClaimProvider(ctx) {
       to: capability.nb.identity.replace('mailto:', ''),
       url,
     })
+
+    return {}
   })
 }

--- a/packages/access-api/src/types/delegations.ts
+++ b/packages/access-api/src/types/delegations.ts
@@ -1,7 +1,7 @@
 import * as Ucanto from '@ucanto/interface'
 
 interface ByAudience {
-  audience: Ucanto.DID<'key'>
+  audience: Ucanto.DID<'key' | 'mailto'>
 }
 export type Query = ByAudience
 

--- a/packages/access-api/test/access-authorize.test.js
+++ b/packages/access-api/test/access-authorize.test.js
@@ -216,6 +216,10 @@ describe('access/authorize', function () {
       'delegations' in claimAsAccountResult,
       'claimAsAccountResult should have delegations property'
     )
+    const claimedAsAccountDelegations = Object.values(
+      claimAsAccountResult.delegations
+    )
+    assert.deepEqual(claimedAsAccountDelegations.length, 0)
   })
 
   it('should receive delegation in the ws', async function () {

--- a/packages/access-api/test/access-authorize.test.js
+++ b/packages/access-api/test/access-authorize.test.js
@@ -140,38 +140,6 @@ describe('access/authorize', function () {
       1,
       'should have claimed 1 delegation'
     )
-
-    let accessDelegateError
-    /** @type {undefined|import('@ucanto/interface').Result<import('@web3-storage/capabilities/types').AccessDelegateSuccess, import('@web3-storage/capabilities/types').AccessDelegateFailure>} */
-    let accessDelegateResult
-    try {
-      accessDelegateResult = await Access.delegate
-        .invoke({
-          issuer,
-          audience: conn.id,
-          with: issuer.did(),
-          nb: {
-            delegations: {},
-          },
-        })
-        .execute(conn)
-    } catch (error) {
-      accessDelegateError = error
-    }
-    // eslint-disable-next-line unicorn/no-useless-undefined
-    assert.deepEqual(accessDelegateError, undefined)
-    assert.ok(accessDelegateResult, 'access/delegate should have result')
-    assert.deepEqual(
-      typeof accessDelegateResult === 'object' &&
-        'name' in accessDelegateResult &&
-        accessDelegateResult.name,
-      'InsufficientStorage',
-      'access/delegate should fail with InsufficientStorage'
-    )
-
-    // @todo once provider/add is implemented, use it to add a storage provider,
-    // then `access/delegate` invocations should get a non-error result
-    // https://github.com/web3-storage/w3protocol/issues/459
   })
 
   it('should receive delegation in the ws', async function () {

--- a/packages/access-api/test/access-authorize.test.js
+++ b/packages/access-api/test/access-authorize.test.js
@@ -95,7 +95,7 @@ describe('access/authorize', function () {
     assert(html.includes(toEmail(accountDID)))
   })
 
-  it('should send confirmation email with link that, when clicked, allows for access/delegate', async function () {
+  it('should send confirmation email with link that, when clicked, allows for access/claim', async function () {
     const { issuer, service, conn, mf } = ctx
     const accountDID = 'did:mailto:dag.house:email'
 
@@ -122,6 +122,23 @@ describe('access/authorize', function () {
       confirmEmailPostResponse.status,
       200,
       'confirmEmailPostResponse status is 200'
+    )
+
+    const claim = Access.claim.invoke({
+      issuer,
+      audience: conn.id,
+      with: issuer.did(),
+    })
+    const claimResult = await claim.execute(conn)
+    assert.ok(
+      'delegations' in claimResult,
+      'claimResult should have delegations property'
+    )
+    const claimedDelegations = claimResult.delegations
+    assert.deepEqual(
+      Object.values(claimedDelegations).length,
+      1,
+      'should have claimed 1 delegation'
     )
 
     let accessDelegateError

--- a/packages/access-api/test/access-authorize.test.js
+++ b/packages/access-api/test/access-authorize.test.js
@@ -153,12 +153,14 @@ describe('access/authorize', function () {
       'should have claimed delegation(s)'
     )
     /**
+     * narrow Ucanto.Proof to Ucanto.Delegation
+     *
      * @param {import('@ucanto/interface').Proof} proof
      */
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const proofDelegation = (proof) => {
       if (!('cid' in proof)) {
-        return
+        throw new Error('proof must be delegation')
       }
       return proof
     }
@@ -180,11 +182,8 @@ describe('access/authorize', function () {
       claimedNb && typeof claimedNb === 'object' && 'proof' in claimedNb,
       'should have nb.proof'
     )
-    const accountToKeyBytes =
-      /** @type {import('@web3-storage/access/types').BytesDelegation} */ (
-        claimedNb.proof
-      )
-    const [expectAccountToKey] = bytesToDelegations(accountToKeyBytes)
+    const expectAccountToKey = proofDelegation(attest.proofs[0])
+    assert.ok(expectAccountToKey, 'expect proofs to contain delegation')
     assert.deepEqual(expectAccountToKey.issuer.did(), accountDID)
     assert.deepEqual(expectAccountToKey.audience.did(), issuer.did())
     assert.deepEqual(expectAccountToKey.capabilities, [

--- a/packages/access-api/test/voucher-claim.test.js
+++ b/packages/access-api/test/voucher-claim.test.js
@@ -1,8 +1,9 @@
-import { Delegation } from '@ucanto/core'
+import { Delegation, invoke } from '@ucanto/core'
 import * as Voucher from '@web3-storage/capabilities/voucher'
 import { stringToDelegation } from '@web3-storage/access/encoding'
 import { context } from './helpers/context.js'
 import assert from 'assert'
+import * as principal from '@ucanto/principal'
 
 /** @type {typeof assert} */
 const t = assert
@@ -65,5 +66,45 @@ describe('ucan', function () {
     } else {
       t.fail('proof should be a delegation')
     }
+  })
+})
+
+describe('voucher/claim', () => {
+  it('invoking delegation from confirmation email should not error', async () => {
+    const { service, conn } = await context()
+    const issuer = await principal.ed25519.generate()
+    const claim = Voucher.claim.invoke({
+      issuer,
+      audience: service,
+      with: issuer.did(),
+      nb: {
+        identity: 'mailto:email@dag.house',
+        product: 'product:free',
+        service: service.did(),
+      },
+    })
+    // @todo should not need to cast to string
+    // this function only returns a string when ENV==='test' and that's weird
+    const claimResult = /** @type {string} */ (await claim.execute(conn))
+    assert.deepEqual(typeof claimResult, 'string', 'claim result is a string')
+    const confirmEmailDelegation = await stringToDelegation(
+      claimResult
+    ).delegate()
+    const confirmEmailReceipt = await invoke({
+      issuer,
+      audience: service,
+      capability: confirmEmailDelegation.capabilities[0],
+      proofs: [confirmEmailDelegation],
+    }).delegate()
+    const [confirmEmailReceiptResult] = await conn.execute(
+      /** @type {any} */ (confirmEmailReceipt)
+    )
+    assert.notDeepEqual(
+      confirmEmailReceiptResult &&
+        'error' in confirmEmailReceiptResult &&
+        confirmEmailReceiptResult.error,
+      true,
+      'invocation result is not an error'
+    )
   })
 })


### PR DESCRIPTION
Motivation:
* #455 
* This implements the second delegation described in https://github.com/web3-storage/w3protocol/issues/457
* make this test pass once we deploy this to staging https://github.com/gobengo/w3protocol-test/pull/6

Test Case:
* https://github.com/gobengo/w3protocol-test/pull/6/files#diff-698e92d7467a4a470689d4cb120272c6cac28864d4960ac12a3720ab7c35a15cR364