### PR TITLE
feat: includes proofs chains in the delegated authorization chain

### DIFF
--- a/packages/access-api/src/service/access-authorize.js
+++ b/packages/access-api/src/service/access-authorize.js
@@ -1,6 +1,3 @@
-// @ts-ignore
-// eslint-disable-next-line no-unused-vars
-import * as Ucanto from '@ucanto/interface'
 import * as Server from '@ucanto/server'
 import * as Access from '@web3-storage/capabilities/access'
 import * as Mailto from '../utils/did-mailto.js'
@@ -11,39 +8,52 @@ import { delegationToString } from '@web3-storage/access/encoding'
  * @param {import('../bindings').RouteContext} ctx
  */
 export function accessAuthorizeProvider(ctx) {
-  return Server.provide(
-    Access.authorize,
-    async ({ capability, invocation }) => {
-      /**
-       * We re-delegate the capability to the account DID and limit it's
-       * lifetime to 15 minutes which should be enough time for the user to
-       * complete the authorization. We don't want to allow authorization for
-       * long time because it could be used by an attacker to gain authorization
-       * by sending second request misleading a user to click a wrong one.
-       */
-      const authorization = await Access.authorize
-        .invoke({
-          issuer: ctx.signer,
-          audience: DID.parse(capability.nb.iss),
-          with: capability.with,
-          lifetimeInSeconds: 60 * 15, // 15 minutes
-          nb: capability.nb,
-          proofs: [invocation],
-        })
-        .delegate()
-
-      const encoded = delegationToString(authorization)
-
-      await ctx.models.accounts.create(capability.nb.iss)
-
-      const url = `${ctx.url.protocol}//${ctx.url.host}/validate-email?ucan=${encoded}&mode=session`
-
-      await ctx.email.sendValidation({
-        to: Mailto.toEmail(capability.nb.iss),
-        url,
+  return Server.provide(Access.authorize, async ({ capability }) => {
+    /**
+     * We delegate to the account DID `access/confirm` capability which will
+     * get embedded in the URL that we send to the user. When user clicks the
+     * link we'll get this delegation back in the `/validate-email` endpoint
+     * which will allow us to verify that it was the user who clicked the link
+     * and not some attacker impersonating the user. We will know that because
+     * the `with` field is our service DID and only private key holder is able
+     * to issue such delegation.
+     *
+     * We limit lifetime of this UCAN to 15 minutes to reduce the attack
+     * surface where an attacker could attempt concurrent authorization
+     * request in attempt confuse a user into clicking the wrong link.
+     */
+    const confirmation = await Access.confirm
+      .invoke({
+        issuer: ctx.signer,
+        audience: DID.parse(capability.nb.iss),
+        // Because with is set to our DID no other actor will be able to issue
+        // this delegation without our private key.
+        with: ctx.signer.did(),
+        lifetimeInSeconds: 60 * 15, // 15 minutes
+        // We link to the authorization request so that this attestation can
+        // not be used to authorize a different request.
+        nb: {
+          // we copy request details and set the `aud` field to the agent DID
+          // that requested the authorization.
+          ...capability.nb,
+          aud: capability.with,
+        },
       })
+      .delegate()
 
-      return {}
-    }
-  )
+    await ctx.models.accounts.create(capability.nb.iss)
+
+    // Encode authorization request and our attestation as string so that it
+    // can be passed as a query parameter in the URL.
+    const encoded = delegationToString(confirmation)
+
+    const url = `${ctx.url.protocol}//${ctx.url.host}/validate-email?ucan=${encoded}&mode=authorize`
+
+    await ctx.email.sendValidation({
+      to: Mailto.toEmail(capability.nb.iss),
+      url,
+    })
+
+    return {}
+  })
 }

--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -31,7 +31,7 @@ export function service(ctx) {
       claim: (...args) => {
         // disable until hardened in test/staging
         if (ctx.config.ENV === 'production') {
-          throw new Error(`acccess/claim invocation handling is not enabled`)
+          throw new Error(`access/claim invocation handling is not enabled`)
         }
         return accessClaimProvider({
           delegations: ctx.models.delegations,
@@ -41,7 +41,7 @@ export function service(ctx) {
       delegate: (...args) => {
         // disable until hardened in test/staging
         if (ctx.config.ENV === 'production') {
-          throw new Error(`acccess/delegate invocation handling is not enabled`)
+          throw new Error(`access/delegate invocation handling is not enabled`)
         }
         return accessDelegateProvider({
           delegations: ctx.models.delegations,

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -23,8 +23,7 @@ import { createD1Database } from './d1.js'
 export function getContext(request, env, ctx) {
   const config = loadConfig(env)
   const email =
-    config.ENV === 'test' ||
-    (config.ENV === 'dev' && env.DEBUG_EMAIL === 'true')
+    config.ENV === 'test' || config.ENV === 'dev'
       ? Email.debug()
       : Email.configure({
           token: config.POSTMARK_TOKEN,

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -23,7 +23,8 @@ import { createD1Database } from './d1.js'
 export function getContext(request, env, ctx) {
   const config = loadConfig(env)
   const email =
-    config.ENV === 'test' || config.ENV === 'dev'
+    config.ENV === 'test' ||
+    (config.ENV === 'dev' && env.DEBUG_EMAIL === 'true')
       ? Email.debug()
       : Email.configure({
           token: config.POSTMARK_TOKEN,

--- a/packages/access-api/test/access-authorize.test.js
+++ b/packages/access-api/test/access-authorize.test.js
@@ -70,10 +70,11 @@ describe('access/authorize', function () {
     t.deepEqual(delegation.audience.did(), accountDID)
     t.deepEqual(delegation.capabilities, [
       {
-        with: issuer.did(),
-        can: 'access/authorize',
+        with: conn.id.did(),
+        can: 'access/confirm',
         nb: {
           iss: accountDID,
+          aud: issuer.did(),
           att: [{ can: '*' }],
         },
       },
@@ -114,15 +115,12 @@ describe('access/authorize', function () {
     }
 
     const url = new URL(email.url)
-    const encoded =
-      /** @type {import('@web3-storage/access/types').EncodedDelegation<[import('@web3-storage/capabilities/types').AccessAuthorize]>} */ (
-        url.searchParams.get('ucan')
-      )
     const rsp = await mf.dispatchFetch(url, { method: 'POST' })
     const html = await rsp.text()
 
-    assert(html.includes(encoded))
+    assert(html.includes('Email Validated'))
     assert(html.includes(toEmail(accountDID)))
+    assert(html.includes(issuer.did()))
   })
 
   // this relies on ./update that is no longer in ucanto

--- a/packages/access-api/test/helpers/ucanto-test-utils.js
+++ b/packages/access-api/test/helpers/ucanto-test-utils.js
@@ -11,7 +11,7 @@ import * as assert from 'assert'
  */
 export function createTesterFromContext(createContext, options) {
   const context = createContext().then(async (ctx) => {
-    await registerSpaces(options?.registerSpaces ?? [], ctx.service, ctx.conn)
+    await registerSpaces(options?.registerSpaces ?? [], ctx)
     return ctx
   })
   const issuer = context.then(({ issuer }) => issuer)
@@ -38,13 +38,14 @@ export function createTesterFromContext(createContext, options) {
  * using a service-issued voucher/redeem invocation
  *
  * @param {Iterable<Resolvable<Ucanto.Principal>>} spaces
- * @param {Ucanto.Signer<Ucanto.DID>} issuer
- * @param {Ucanto.ConnectionView<Record<string, any>>} conn
+ * @param {object} options
+ * @param {Ucanto.Signer<Ucanto.DID>} options.service
+ * @param {Ucanto.ConnectionView<Record<string, any>>} options.conn
  */
-export async function registerSpaces(spaces, issuer, conn) {
+export async function registerSpaces(spaces, { service, conn }) {
   for (const spacePromise of spaces) {
     const space = await spacePromise
-    const redeem = await spaceRegistrationInvocation(issuer, space.did())
+    const redeem = await spaceRegistrationInvocation(service, space.did())
     const results = await conn.execute(redeem)
     assert.deepEqual(
       results.length,

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -84,7 +84,7 @@ export const confirm = capability({
   with: DID,
   nb: Schema.struct({
     iss: Account,
-    aud: DID,
+    aud: Schema.did(),
     att: CapabilityRequest.array(),
   }),
   derives: (claim, proof) => {

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -40,6 +40,7 @@ export type AccessDelegateSuccess = unknown
 export type AccessDelegateFailure = { error: true } | InsufficientStorage
 
 export type AccessSession = InferInvokedCapability<typeof AccessCaps.session>
+export type AccessConfirm = InferInvokedCapability<typeof AccessCaps.confirm>
 
 // Space
 export type Space = InferInvokedCapability<typeof space>

--- a/packages/capabilities/test/capabilities/access.test.js
+++ b/packages/capabilities/test/capabilities/access.test.js
@@ -359,7 +359,7 @@ describe('access capabilities', function () {
         assert.fail('error in self issue')
       } else {
         assert.deepEqual(result.audience.did(), service.did())
-        assert.equal(result.capability.can, 'access/authorize')
+        assert.equal(result.capability.can, 'access/confirm')
         assert.deepEqual(result.capability.nb, {
           iss: 'did:mailto:web3.storage:test',
           aud: agent.did(),
@@ -368,7 +368,7 @@ describe('access capabilities', function () {
       }
     })
 
-    it('should delegate from authorize to authorize', async function () {
+    it('should delegate from confirm to confirm', async function () {
       const agent1 = bob
       const agent2 = mallory
       const ucan = Access.confirm.invoke({
@@ -381,7 +381,7 @@ describe('access capabilities', function () {
           att: [{ can: '*' }],
         },
         proofs: [
-          await Access.authorize.delegate({
+          await Access.confirm.delegate({
             issuer: agent1,
             audience: agent2,
             with: agent1.did(),
@@ -405,6 +405,7 @@ describe('access capabilities', function () {
         assert.equal(result.capability.can, 'access/confirm')
         assert.deepEqual(result.capability.nb, {
           iss: 'did:mailto:web3.storage:test',
+          aud: agent2.did(),
           att: [{ can: '*' }],
         })
       }
@@ -602,7 +603,7 @@ describe('access capabilities', function () {
           att: [{ can: '*' }],
         },
         proofs: [
-          await Access.authorize.delegate({
+          await Access.confirm.delegate({
             issuer: alice,
             audience: bob,
             with: alice.did(),


### PR DESCRIPTION
This pr cleans up bunch of mess in the access/authorize code path and starts including proof chains in the delegated authorization so agents can actually utilize delegations.