### PR TITLE
fix: adjust migration 0005 to not do a drop table and instead rename delegations -> delegations_old and create a new delegations

### DIFF
--- a/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
+++ b/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
@@ -11,8 +11,10 @@ So here we will:
 * rename delegations_new -> delegations
 */
 
+ALTER TABLE delegations RENAME TO delegations_deleted_1677807019;
+
 CREATE TABLE
-    IF NOT EXISTS delegations_new (
+    IF NOT EXISTS delegations (
         cid TEXT NOT NULL PRIMARY KEY,
         bytes BLOB NOT NULL,
         audience TEXT NOT NULL,
@@ -23,8 +25,5 @@ CREATE TABLE
         UNIQUE (cid)
     );
 
-INSERT INTO delegations_new (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
-SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations;
-
-DROP TABLE delegations;
-ALTER TABLE delegations_new RENAME TO delegations;
+INSERT INTO delegations (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
+SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations_deleted_1677807019;

--- a/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
+++ b/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
@@ -26,5 +26,5 @@ CREATE TABLE
 INSERT INTO delegations_new (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
 SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations;
 
-DROP TABLE delegations;
+ALTER TABLE delegations RENAME TO delegations_1677808856;
 ALTER TABLE delegations_new RENAME TO delegations;

--- a/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
+++ b/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
@@ -11,10 +11,8 @@ So here we will:
 * rename delegations_new -> delegations
 */
 
-ALTER TABLE delegations RENAME TO delegations_deleted_1677807019;
-
 CREATE TABLE
-    IF NOT EXISTS delegations (
+    IF NOT EXISTS delegations_new (
         cid TEXT NOT NULL PRIMARY KEY,
         bytes BLOB NOT NULL,
         audience TEXT NOT NULL,
@@ -25,5 +23,8 @@ CREATE TABLE
         UNIQUE (cid)
     );
 
-INSERT INTO delegations (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
-SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations_deleted_1677807019;
+INSERT INTO delegations_new (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
+SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations;
+
+DROP TABLE delegations;
+ALTER TABLE delegations_new RENAME TO delegations;


### PR DESCRIPTION
Note:
* this is just for consideration because @Gozala and I are both curious whether cloudflare migrations will allow the rename. It would be good to know.
* But i actually think it would probably be best to use https://github.com/web3-storage/w3protocol/pull/469 over time

Motivation:
* try out something @Gozala and I came up with for https://github.com/web3-storage/w3protocol/issues/464