### PR TITLE
fix: adjust migration 0005 to keep delegations table but create new used delegations_v2

### DIFF
--- a/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
+++ b/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
@@ -11,8 +11,10 @@ So here we will:
 * rename delegations_new -> delegations
 */
 
+ALTER TABLE delegations RENAME TO delegations_deleted_1677807019;
+
 CREATE TABLE
-    IF NOT EXISTS delegations_new (
+    IF NOT EXISTS delegations (
         cid TEXT NOT NULL PRIMARY KEY,
         bytes BLOB NOT NULL,
         audience TEXT NOT NULL,
@@ -23,8 +25,5 @@ CREATE TABLE
         UNIQUE (cid)
     );
 
-INSERT INTO delegations_new (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
-SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations;
-
-DROP TABLE delegations;
-ALTER TABLE delegations_new RENAME TO delegations;
+INSERT INTO delegations (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
+SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations_deleted_1677807019;

--- a/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
+++ b/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
@@ -5,16 +5,11 @@ goal: remove the foreign key constraint on delegations.audience -> accounts.did.
 We want to be able to store delegations whose audience is not an account did.
 
 sqlite doesn't support `alter table drop constraint`.
-So here we will:
-* create delegations_new table without the constraint
-* insert all from delegations -> delegations_new
-* rename delegations_new -> delegations
+AND cloudflare d1 doesn't support `DROP TABLE`
 */
 
-ALTER TABLE delegations RENAME TO delegations_deleted_1677807019;
-
 CREATE TABLE
-    IF NOT EXISTS delegations (
+    IF NOT EXISTS delegations_v2 (
         cid TEXT NOT NULL PRIMARY KEY,
         bytes BLOB NOT NULL,
         audience TEXT NOT NULL,
@@ -25,5 +20,5 @@ CREATE TABLE
         UNIQUE (cid)
     );
 
-INSERT INTO delegations (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
-SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations_deleted_1677807019;
+INSERT INTO delegations_v2 (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
+SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations;

--- a/packages/access-api/src/models/accounts.js
+++ b/packages/access-api/src/models/accounts.js
@@ -1,9 +1,5 @@
 // eslint-disable-next-line no-unused-vars
 import * as Ucanto from '@ucanto/interface'
-import {
-  delegationsToBytes,
-  expirationToDate,
-} from '@web3-storage/access/encoding'
 import { Kysely } from 'kysely'
 import { D1Dialect } from 'kysely-d1'
 import { GenericPlugin } from '../utils/d1.js'
@@ -52,26 +48,6 @@ export class Accounts {
   }
 
   /**
-   *
-   * @param {Ucanto.Delegation} del
-   */
-  async addDelegation(del) {
-    const result = await this.d1
-      .insertInto('delegations')
-      .values({
-        cid: del.cid.toV1().toString(),
-        audience: del.audience.did(),
-        issuer: del.issuer.did(),
-        bytes: delegationsToBytes([del]),
-        expires_at: expirationToDate(del.expiration),
-      })
-      .onConflict((oc) => oc.column('cid').doNothing())
-      .returningAll()
-      .executeTakeFirst()
-    return result
-  }
-
-  /**
    * @param {Ucanto.URI<"did:">} did
    */
   async get(did) {
@@ -79,34 +55,6 @@ export class Accounts {
       .selectFrom('accounts')
       .selectAll()
       .where('accounts.did', '=', did)
-      .executeTakeFirst()
-  }
-
-  /**
-   * @param {Ucanto.URI<"did:">} did
-   */
-  async getDelegations(did) {
-    return await this.d1
-      .selectFrom('delegations')
-      .selectAll()
-      .where('delegations.audience', '=', did)
-      .execute()
-  }
-
-  /**
-   * @param {string} cid
-   */
-  async getDelegationsByCid(cid) {
-    return await this.d1
-      .selectFrom('delegations')
-      .selectAll()
-      .where('delegations.cid', '=', cid)
-      .where((qb) =>
-        qb
-          .where('delegations.expires_at', '>=', new Date())
-          // eslint-disable-next-line unicorn/no-null
-          .orWhere('delegations.expires_at', 'is', null)
-      )
       .executeTakeFirst()
   }
 }


### PR DESCRIPTION
Motivation:
* similar to https://github.com/web3-storage/w3protocol/pull/468

I think this is the one we should actually do, even though it is a little ugly to call the table `delegations_v2`.
If d1 can't do DROP TABLE, then I think the safest thing to do is to avoid it and always only ever create new ones. We can migrate to new tables and update the table name access-api uses in the same commit/pr.