### PR TITLE
fix: revert migration 0005 experiment

### DIFF
--- a/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
+++ b/packages/access-api/migrations/0005_drop_delegations_audience_to_accounts_did_fk.sql
@@ -26,5 +26,5 @@ CREATE TABLE
 INSERT INTO delegations_new (cid, bytes, audience, issuer, expiration, inserted_at, updated_at)
 SELECT cid, bytes, audience, issuer, expiration, inserted_at, updated_at FROM delegations;
 
-ALTER TABLE delegations RENAME TO delegations_1677808856;
+DROP TABLE delegations;
 ALTER TABLE delegations_new RENAME TO delegations;


### PR DESCRIPTION
Reverts web3-storage/w3protocol#468

It's slightly better how it was, because it doesn't leave a dangling table around on localdev.
Running this version with no drops *also* didn't successfully apply, so it wasn't an improvement.
