### PR TITLE
fix: DbDelegationsStorage#find throws UnexpectedDelegation w/ { row } if failed bytesToDelegations

### DIFF
--- a/packages/access-api/test/delegations-storage.test.js
+++ b/packages/access-api/test/delegations-storage.test.js
@@ -70,7 +70,7 @@ describe('DbDelegationsStorage', () => {
     assert.deepEqual(carolDelegations.length, 0)
   })
 
-  it('find can handle rows with empty bytes', async () => {
+  it('find throws UnexpectedDelegation when encountering row with empty bytes', async () => {
     const { d1, issuer } = await context()
     const db = createD1Database(d1)
     const delegations = new DbDelegationsStorage(db)


### PR DESCRIPTION
Motivation:
* aid in debugging #471 
* hope this
  * confirms that this error is coming from `DbDelegationsStorage#find` (I see '.find' in the hard-to-read sentry stack trace)
  * gives insight into what the db row is like (esp `row.bytes`) that can't be parsed