### PR TITLE
fix: switch upload-api to node16

### DIFF
--- a/.github/workflows/upload-api.yml
+++ b/.github/workflows/upload-api.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
 
@@ -60,7 +60,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
 

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -48,8 +48,8 @@
     "build": "tsc --build",
     "check": "tsc --build",
     "lint": "tsc --build",
-    "test": "mocha --bail --timeout 10s -n no-warnings -n experimental-vm-modules test/**/*.spec.js",
-    "test-watch": "pnpm build && mocha --bail --timeout 10s --watch --parallel -n no-warnings -n experimental-vm-modules --watch-files src,test"
+    "test": "mocha --bail --timeout 10s -n no-warnings -n experimental-vm-modules -n experimental-fetch test/**/*.spec.js",
+    "test-watch": "pnpm build && mocha --bail --timeout 10s --watch --parallel -n no-warnings -n experimental-vm-modules -n experimental-fetch --watch-files src,test"
   },
   "dependencies": {
     "@ucanto/client": "^5.1.0",
@@ -66,7 +66,9 @@
     "@types/mocha": "^10.0.1",
     "@ucanto/core": "^5.1.0",
     "@web3-storage/sigv4": "^1.0.2",
-    "mocha": "^10.2.0"
+    "@web-std/blob": "^3.0.4",
+    "mocha": "^10.2.0",
+    "hd-scripts": "^4.1.0"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -3,6 +3,12 @@
   "version": "1.0.2",
   "type": "module",
   "main": "./src/lib.js",
+  "files": [
+    "src",
+    "test",
+    "dist/src/**/*.d.ts",
+    "dist/src/**/*.d.ts.map"
+  ],
   "typesVersions": {
     "*": {
       "src/lib.js": [
@@ -104,6 +110,20 @@
     "ignorePatterns": [
       "dist",
       "coverage"
+    ]
+  },
+  "depcheck": {
+    "specials": [
+      "bin"
+    ],
+    "ignorePatterns": [
+      "dist"
+    ],
+    "ignores": [
+      "dist",
+      "@types/*",
+      "hd-scripts",
+      "eslint-config-prettier"
     ]
   },
   "engines": {

--- a/packages/upload-api/test/car-store-bucket.js
+++ b/packages/upload-api/test/car-store-bucket.js
@@ -40,6 +40,8 @@ export class CarStoreBucket {
       }
 
       response.end()
+      // otherwise it keep connection lingering
+      response.destroy()
     })
     await new Promise((resolve) => server.listen(resolve))
 
@@ -80,7 +82,11 @@ export class CarStoreBucket {
    */
   deactivate() {
     return new Promise((resolve, reject) => {
-      this.server.closeAllConnections()
+      // does not exist in node 16
+      if (typeof this.server.closeAllConnections === 'function') {
+        this.server.closeAllConnections()
+      }
+
       this.server.close((error) => {
         if (error) {
           reject(error)

--- a/packages/upload-api/test/util.js
+++ b/packages/upload-api/test/util.js
@@ -7,6 +7,7 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import * as CAR from '@ucanto/transport/car'
 import * as raw from 'multiformats/codecs/raw'
 import { CarWriter } from '@ipld/car'
+import { Blob } from '@web-std/blob'
 
 /** did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi */
 export const alice = ed25519.parse(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,10 @@ importers:
       '@ucanto/principal': ^5.1.0
       '@ucanto/server': ^6.0.0
       '@ucanto/transport': ^5.1.0
+      '@web-std/blob': ^3.0.4
       '@web3-storage/capabilities': ^3.0.0
       '@web3-storage/sigv4': ^1.0.2
+      hd-scripts: ^4.1.0
       mocha: ^10.2.0
       multiformats: ^11.0.1
       p-retry: ^5.1.2
@@ -317,7 +319,9 @@ importers:
       '@ipld/car': 5.1.0
       '@types/mocha': 10.0.1
       '@ucanto/core': 5.1.0
+      '@web-std/blob': 3.0.4
       '@web3-storage/sigv4': 1.0.2
+      hd-scripts: 4.1.0
       mocha: 10.2.0
 
   packages/upload-client:
@@ -3666,7 +3670,6 @@ packages:
     dependencies:
       '@web-std/stream': 1.0.0
       web-encoding: 1.1.5
-    dev: false
 
   /@web-std/fetch/4.1.0:
     resolution: {integrity: sha512-ZRizMcP8YyuRlhIsRYNFD9x/w28K7kbUhNGmKM9hDy4qeQ5xMTk//wA89EF+Clbl6EP4ksmCcN+4TqBMSRL8Zw==}
@@ -3690,7 +3693,6 @@ packages:
     resolution: {integrity: sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==}
     dependencies:
       web-streams-polyfill: 3.2.1
-    dev: false
 
   /@web-std/stream/1.0.1:
     resolution: {integrity: sha512-tsz4Y0WNDgFA5jwLSeV7/UV5rfMIlj0cPsSLVfTihjaVW0OJPd5NxJ3le1B3yLyqqzRpeG5OAfJAADLc4VoGTA==}
@@ -3833,7 +3835,6 @@ packages:
   /@zxing/text-encoding/0.9.0:
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /abort-controller/3.0.0:
@@ -7423,6 +7424,36 @@ packages:
 
   /hd-scripts/4.0.0:
     resolution: {integrity: sha512-eIkbX+8aAva5t6wvTMCxl90uKm5sXcjY20d+aEokHqu5I/MJECFbbkbnjUhYZVsKg1q2wuF9pnV9RrErHt5jyQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.50.0_go4drrxstycfikanvu45pi4vgq
+      '@typescript-eslint/parser': 5.50.0_4vsywjlpuriuw3tl5oq6zy5a64
+      eslint: 8.33.0
+      eslint-config-prettier: 8.6.0_eslint@8.33.0
+      eslint-config-standard: 17.0.0_xh3wrndcszbt2l7hdksdjqnjcq
+      eslint-config-standard-with-typescript: 30.0.0_frfgwa7fqjzszldru3sxumpviq
+      eslint-plugin-etc: 2.0.2_4vsywjlpuriuw3tl5oq6zy5a64
+      eslint-plugin-import: 2.27.5_ufewo3pl5nnmz6lltvjrdi2hii
+      eslint-plugin-jsdoc: 39.7.5_eslint@8.33.0
+      eslint-plugin-n: 15.6.1_eslint@8.33.0
+      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-promise: 6.1.1_eslint@8.33.0
+      eslint-plugin-react: 7.32.2_eslint@8.33.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.33.0
+      eslint-plugin-unicorn: 45.0.2_eslint@8.33.0
+      lint-staged: 13.1.0
+      prettier: 2.8.3
+      simple-git-hooks: 2.8.1
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - enquirer
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /hd-scripts/4.1.0:
+    resolution: {integrity: sha512-nDWeib3SxaHZRz0YhRkOnBDT5LAyMx6BXITO5xsocUJh4bSaqn7ha/h9Zlhw0WLtfxSVEXv96kjp/LQts12B9A==}
     engines: {node: '>=14'}
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.50.0_go4drrxstycfikanvu45pi4vgq
@@ -12466,7 +12497,6 @@ packages:
       util: 0.12.5
     optionalDependencies:
       '@zxing/text-encoding': 0.9.0
-    dev: false
 
   /web-namespaces/1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
@@ -12475,7 +12505,6 @@ packages:
   /web-streams-polyfill/3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
-    dev: false
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}


### PR DESCRIPTION
Running tests in w3infra failed because `Blob` is not in node16. Change ci to use node 16 for upload-api to avoid this problem.