### PR TITLE
feat: space/info will not error for spaces that have had storage provider added via provider/add

### DIFF
--- a/packages/access-api/src/models/spaces.js
+++ b/packages/access-api/src/models/spaces.js
@@ -7,7 +7,7 @@ import { D1Dialect } from 'kysely-d1'
 import { D1Error, GenericPlugin } from '../utils/d1.js'
 
 /**
- * @typedef {import('@web3-storage/access/src/types.js').SpaceRecord} SpaceRecord
+ * @typedef {import('@web3-storage/access/src/types.js').SpaceTable} SpaceTable
  */
 
 /**
@@ -19,7 +19,7 @@ export class Spaces {
    * @param {D1Database} d1
    */
   constructor(d1) {
-    /** @type {GenericPlugin<SpaceRecord>} */
+    /** @type {GenericPlugin<import('kysely').Selectable<SpaceTable>>} */
     const objectPlugin = new GenericPlugin({
       metadata: (v) => {
         // this will be `EMPTY` because it's the default value in the sql schema

--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -240,9 +240,9 @@ export function service(ctx) {
  * @returns {Promise<boolean>}
  */
 async function spaceHasStorageProvider(space, spaces, provisions) {
-  return Boolean(
+  return (
     (await spaceHasStorageProviderFromProviderAdd(space, provisions)) ||
-      (await spaceHasStorageProviderFromVoucherRedeem(space, spaces))
+    (await spaceHasStorageProviderFromVoucherRedeem(space, spaces))
   )
 }
 

--- a/packages/access-api/src/service/index.js
+++ b/packages/access-api/src/service/index.js
@@ -1,6 +1,7 @@
 import * as ucanto from '@ucanto/core'
 import * as Ucanto from '@ucanto/interface'
 import * as Server from '@ucanto/server'
+import * as validator from '@ucanto/validator'
 import { Failure } from '@ucanto/server'
 import * as Space from '@web3-storage/capabilities/space'
 import { top } from '@web3-storage/capabilities/top'
@@ -15,6 +16,7 @@ import { accessAuthorizeProvider } from './access-authorize.js'
 import { accessDelegateProvider } from './access-delegate.js'
 import { accessClaimProvider } from './access-claim.js'
 import { providerAddProvider } from './provider-add.js'
+import { Spaces } from '../models/spaces.js'
 
 /**
  * @param {import('../bindings').RouteContext} ctx
@@ -24,6 +26,9 @@ import { providerAddProvider } from './provider-add.js'
  * }
  */
 export function service(ctx) {
+  /** @param {Ucanto.DID<'key'>} space */
+  const hasStorageProvider = async (space) =>
+    spaceHasStorageProvider(space, ctx.models.spaces, ctx.models.provisions)
   return {
     store: uploadApi.createStoreProxy(ctx),
     upload: uploadApi.createUploadProxy(ctx),
@@ -47,19 +52,7 @@ export function service(ctx) {
         }
         return accessDelegateProvider({
           delegations: ctx.models.delegations,
-          hasStorageProvider: async (space) => {
-            /** @type {import('./access-delegate.js').HasStorageProvider} */
-            const registeredViaVoucherRedeem = async (space) =>
-              Boolean(await ctx.models.spaces.get(space))
-            /** @type {import('./access-delegate.js').HasStorageProvider} */
-            // eslint-disable-next-line unicorn/consistent-function-scoping
-            const registeredViaProviderAdd = (space) =>
-              ctx.models.provisions.hasStorageProvider(space)
-            return Boolean(
-              (await registeredViaProviderAdd(space)) ||
-                (await registeredViaVoucherRedeem(space))
-            )
-          },
+          hasStorageProvider,
         })(...args)
       },
     },
@@ -81,8 +74,27 @@ export function service(ctx) {
 
     space: {
       info: Server.provide(Space.info, async ({ capability, invocation }) => {
-        const results = await ctx.models.spaces.get(capability.with)
-        if (!results) {
+        const spaceDid = capability.with
+        if (!validator.DID.match({ method: 'key' }).is(spaceDid)) {
+          /** @type {import('@web3-storage/access/types').SpaceUnknown} */
+          const unexpectedSpaceDidFailure = {
+            error: true,
+            name: 'SpaceUnknown',
+            message: `can only get info for did:key spaces`,
+          }
+          return unexpectedSpaceDidFailure
+        }
+        if (
+          await spaceHasStorageProviderFromProviderAdd(
+            spaceDid,
+            ctx.models.provisions
+          )
+        ) {
+          return { did: spaceDid }
+        }
+        // this only exists if the space was registered via voucher/redeem
+        const space = await ctx.models.spaces.get(capability.with)
+        if (!space) {
           /** @type {import('@web3-storage/access/types').SpaceUnknown} */
           const spaceUnknownFailure = {
             error: true,
@@ -91,7 +103,8 @@ export function service(ctx) {
           }
           return spaceUnknownFailure
         }
-        return results
+        /** @type {import('@web3-storage/access/types').SpaceRecord} */
+        return space
       }),
       recover: Server.provide(
         Space.recover,
@@ -218,4 +231,37 @@ export function service(ctx) {
       },
     },
   }
+}
+
+/**
+ * @param {Ucanto.DID<'key'>} space
+ * @param {Spaces} spaces
+ * @param {import('../types/provisions.js').ProvisionsStorage} provisions
+ * @returns {Promise<boolean>}
+ */
+async function spaceHasStorageProvider(space, spaces, provisions) {
+  return Boolean(
+    (await spaceHasStorageProviderFromProviderAdd(space, provisions)) ||
+      (await spaceHasStorageProviderFromVoucherRedeem(space, spaces))
+  )
+}
+
+/**
+ * @param {Ucanto.DID<'key'>} space
+ * @param {Spaces} spaces
+ * @returns {Promise<boolean>}
+ */
+async function spaceHasStorageProviderFromVoucherRedeem(space, spaces) {
+  const registered = Boolean(await spaces.get(space))
+  return registered
+}
+
+/**
+ * @param {Ucanto.DID<'key'>} space
+ * @param {import('../types/provisions.js').ProvisionsStorage} provisions
+ * @returns {Promise<boolean>}
+ */
+async function spaceHasStorageProviderFromProviderAdd(space, provisions) {
+  const registeredViaProviderAdd = await provisions.hasStorageProvider(space)
+  return registeredViaProviderAdd
 }

--- a/packages/access-api/test/provider-add.test.js
+++ b/packages/access-api/test/provider-add.test.js
@@ -259,6 +259,8 @@ for (const accessApiVariant of /** @type {const} */ ([
         .delegate()
       const spaceInfoResult = await accessApiVariant.invoke(spaceInfo)
       assertNotError(spaceInfoResult)
+      assert.ok('did' in spaceInfoResult)
+      assert.deepEqual(spaceInfoResult.did, space.did())
     })
   }
 }

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -77,6 +77,7 @@ export type SpaceInfoResult =
       did: DID<'key'>
     }
   // deprecated and may be removed if voucher/redeem is removed
+  /** @deprecated */
   | SpaceRecord
 
 export interface AccountTable {

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -70,6 +70,15 @@ export interface SpaceTable {
 }
 export type SpaceRecord = Selectable<SpaceTable>
 
+export type SpaceInfoResult =
+  // w3up spaces registered via provider/add will have this
+  | {
+      // space did
+      did: DID<'key'>
+    }
+  // deprecated and may be removed if voucher/redeem is removed
+  | SpaceRecord
+
 export interface AccountTable {
   did: URI<'did:'>
   inserted_at: Generated<Date>
@@ -119,7 +128,7 @@ export interface Service {
     redeem: ServiceMethod<VoucherRedeem, void, Failure>
   }
   space: {
-    info: ServiceMethod<SpaceInfo, SpaceRecord, Failure | SpaceUnknown>
+    info: ServiceMethod<SpaceInfo, SpaceInfoResult, Failure | SpaceUnknown>
     'recover-validation': ServiceMethod<
       SpaceRecoverValidation,
       EncodedDelegation<[SpaceRecover]> | undefined,


### PR DESCRIPTION
Motivation:
* #497 
* @Gozala and I talked about doing this minimally just to make sure that when w3infra calls this as part of handling `store/add` that it will work.