### PR TITLE
fix: DbProvisionsStorage putMany doesnt error on cid col conflict

### DIFF
--- a/packages/access-api/src/models/provisions.js
+++ b/packages/access-api/src/models/provisions.js
@@ -85,6 +85,14 @@ export class DbProvisions {
     await this.#db
       .insertInto(this.tableNames.provisions)
       .values(rows)
+      .onConflict((oc) => {
+        // if cid conflicts, update columns w/ values from conflicting insert
+        return oc.column('cid').doUpdateSet({
+          consumer: (eb) => eb.ref('excluded.consumer'),
+          provider: (eb) => eb.ref('excluded.provider'),
+          sponsor: (eb) => eb.ref('excluded.sponsor'),
+        })
+      })
       .executeTakeFirstOrThrow()
   }
 

--- a/packages/access-api/src/service/provider-add.js
+++ b/packages/access-api/src/service/provider-add.js
@@ -35,7 +35,7 @@ export function createProviderAddHandler(options) {
         message: 'Issuer must be a mailto DID',
       }
     }
-    await options.provisions.putMany({
+    await options.provisions.put({
       invocation,
       space: consumer,
       provider,

--- a/packages/access-api/src/types/provisions.ts
+++ b/packages/access-api/src/types/provisions.ts
@@ -19,11 +19,11 @@ export interface Provision {
 export interface ProvisionsStorage {
   hasStorageProvider: (consumer: Ucanto.DID<'key'>) => Promise<boolean>
   /**
-   * write several items into storage
+   * ensure item is stored
    *
-   * @param items - provisions to store
+   * @param item - provision to store
    */
-  putMany: (...items: Provision[]) => Promise<void>
+  put: (item: Provision) => Promise<void>
 
   /**
    * get number of stored items

--- a/packages/access-api/test/provisions.test.js
+++ b/packages/access-api/test/provisions.test.js
@@ -81,7 +81,10 @@ describe('DbProvisions', () => {
       modifiedFirstProvision.space
     )
     assert.deepEqual(provisionForFakeConsumer.length, 0)
-    // count umodified
-    assert.deepEqual(await storage.count(), count)
+    assert.deepEqual(
+      await storage.count(),
+      count,
+      'count was not increased by put w/ existing cid'
+    )
   })
 })

--- a/packages/access-api/test/provisions.test.js
+++ b/packages/access-api/test/provisions.test.js
@@ -57,5 +57,18 @@ describe('DbProvisions', () => {
     // all of lastProvisions are duplicate, but firstProvision is new so that should be added
     await storage.putMany(...lastProvisions, firstProvision)
     assert.deepEqual(await storage.count(), count)
+
+    // but if we try to store the same provision (same `cid`) with different
+    // fields derived from invocation, it should error
+    const modifiedFirstProvision = {
+      ...firstProvision,
+      space: /** @type {const} */ ('did:key:foo'),
+    }
+    const putModifiedFirstProvision = () =>
+      storage.putMany(modifiedFirstProvision)
+    await assert.rejects(
+      putModifiedFirstProvision(),
+      'cannot putMany with same cid but different derived fields'
+    )
   })
 })


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/482

* [x] first draft

After 2023-03-09 review with @Gozala :
* [x] add test for updating Provision with same invocation cid but different derived 
fields. it should result in error
* [x] make test pass, probably by changing the kysely to be 'on conflict, do nothing as long as the derived columns are identical, otherwise error'
  * it wasn't really possible to do that on conflict logic as far as I could tell, at least through our `kysely` orm
  * kysely doesn't expose methods for all the [`on conflict` clauses that sqlite should support](https://www.sqlite.org/lang_conflict.html)
  * I pursued something like [this using CTE](https://stackoverflow.com/a/49601238), only to find out [sqlite doesn't support `insert` in cte](https://sqlite.org/forum/forumpost/b44ca81f043bed9f)