### PR TITLE
feat: add access-api + access-client agent test and improve types

### DIFF
--- a/packages/access-api/src/types/ucanto.ts
+++ b/packages/access-api/src/types/ucanto.ts
@@ -1,7 +1,8 @@
 import * as Ucanto from '@ucanto/interface'
 
-export type ServiceInvoke<Service extends Record<string, any>> = <
-  Capability extends Ucanto.Capability
->(
-  invocation: Ucanto.ServiceInvocation<Capability, Service>
+export type ServiceInvoke<
+  Service extends Record<string, any>,
+  InvocationCapabilities extends Ucanto.Capability = Ucanto.Capability
+> = <Capability extends InvocationCapabilities>(
+  invocation: Ucanto.ServiceInvocation<Capability>
 ) => Promise<Ucanto.InferServiceInvocationReturn<Capability, Service>>

--- a/packages/access-api/src/types/ucanto.ts
+++ b/packages/access-api/src/types/ucanto.ts
@@ -1,0 +1,7 @@
+import * as Ucanto from '@ucanto/interface'
+
+export type ServiceInvoke<Service extends Record<string, any>> = <
+  Capability extends Ucanto.Capability
+>(
+  invocation: Ucanto.ServiceInvocation<Capability, Service>
+) => Promise<Ucanto.InferServiceInvocationReturn<Capability, Service>>

--- a/packages/access-api/test/access-client-agent.test.js
+++ b/packages/access-api/test/access-client-agent.test.js
@@ -1,0 +1,31 @@
+import { context } from './helpers/context.js'
+import { createTesterFromContext } from './helpers/ucanto-test-utils.js'
+import * as principal from '@ucanto/principal'
+import { Agent as AccessAgent } from '@web3-storage/access/agent'
+import * as assert from 'assert'
+
+for (const accessApiVariant of /** @type {const} */ ([
+  {
+    name: 'using access-api in miniflare',
+    ...(() => {
+      const spaceWithStorageProvider = principal.ed25519.generate()
+      return {
+        spaceWithStorageProvider,
+        ...createTesterFromContext(context, {
+          registerSpaces: [spaceWithStorageProvider],
+        }),
+      }
+    })(),
+  },
+])) {
+  describe(`access-client-agent ${accessApiVariant.name}`, () => {
+    it('can be used with access-client agent', async () => {
+      const accessAgent = await AccessAgent.create(undefined, {
+        connection: await accessApiVariant.connection,
+      })
+      const space = await accessAgent.createSpace('test-add')
+      const delegations = accessAgent.proofs()
+      assert.equal(space.proof.cid, delegations[0].cid)
+    })
+  })
+}

--- a/packages/access-api/test/access-delegate.test.js
+++ b/packages/access-api/test/access-delegate.test.js
@@ -203,6 +203,7 @@ for (const variant of /** @type {const} */ ([
     // test delegate, then claim
     it('can delegate, then claim', async () => {
       await testCanDelegateThenClaim(
+        // @ts-ignore
         variant.invoke,
         await variant.spaceWithStorageProvider,
         await variant.audience

--- a/packages/access-api/test/access-delegate.test.js
+++ b/packages/access-api/test/access-delegate.test.js
@@ -6,13 +6,10 @@ import * as Ucanto from '@ucanto/interface'
 import * as ucanto from '@ucanto/core'
 import * as principal from '@ucanto/principal'
 import { createAccessDelegateHandler } from '../src/service/access-delegate.js'
-import { createAccessClaimHandler } from '../src/service/access-claim.js'
 import {
   createDelegationsStorage,
   toDelegationsDict,
 } from '../src/service/delegations.js'
-import { createD1Database } from '../src/utils/d1.js'
-import { DbDelegationsStorage } from '../src/models/delegations.js'
 import * as delegationsResponse from '../src/utils/delegations-response.js'
 import {
   assertNotError,
@@ -123,70 +120,6 @@ async function testCanAccessDelegateWithRegisteredSpace(options) {
  */
 for (const variant of /** @type {const} */ ([
   {
-    name: 'handled by createAccessHandler using array createDelegationsStorage',
-    ...(() => {
-      const spaceWithStorageProvider = principal.ed25519.generate()
-      return {
-        spaceWithStorageProvider,
-        ...createTesterFromHandler(
-          (() => {
-            const delegations = createDelegationsStorage()
-            return () => {
-              return createAccessHandler(
-                createAccessDelegateHandler({
-                  delegations,
-                  hasStorageProvider: async (uri) => {
-                    return (
-                      uri ===
-                      (await spaceWithStorageProvider.then((s) => s.did()))
-                    )
-                  },
-                }),
-                createAccessClaimHandler({ delegations })
-              )
-            }
-          })()
-        ),
-      }
-    })(),
-  },
-  {
-    name: 'handled by createAccessHandler using DbDelegationsStorage',
-    ...(() => {
-      const spaceWithStorageProvider = principal.ed25519.generate()
-      const d1 = context().then((ctx) => ctx.d1)
-      const database = d1.then((d1) => createD1Database(d1))
-      const delegations = database.then((db) => new DbDelegationsStorage(db))
-      return {
-        spaceWithStorageProvider,
-        ...createTesterFromHandler(
-          (() => {
-            return () => {
-              /**
-               * @type {InvocationHandler<AccessDelegate | AccessClaim, unknown, { error: true }>}
-               */
-              return async (invocation) => {
-                const handle = createAccessHandler(
-                  createAccessDelegateHandler({
-                    delegations: await delegations,
-                    hasStorageProvider: async (uri) => {
-                      return (
-                        uri ===
-                        (await spaceWithStorageProvider.then((s) => s.did()))
-                      )
-                    },
-                  }),
-                  createAccessClaimHandler({ delegations: await delegations })
-                )
-                return handle(invocation)
-              }
-            }
-          })()
-        ),
-      }
-    })(),
-  },
-  {
     name: 'handled by access-api in miniflare',
     ...(() => {
       const spaceWithStorageProvider = principal.ed25519.generate()
@@ -203,7 +136,6 @@ for (const variant of /** @type {const} */ ([
     // test delegate, then claim
     it('can delegate, then claim', async () => {
       await testCanDelegateThenClaim(
-        // @ts-ignore
         variant.invoke,
         await variant.spaceWithStorageProvider,
         await variant.audience
@@ -444,7 +376,11 @@ async function testInsufficientStorageIfNoStorageProvider(options) {
  */
 
 /**
- * @param {InvocationHandler<AccessDelegate | AccessClaim, unknown, { error: true }>} invoke
+ * @typedef {import('@web3-storage/access/types').Service} AccessService
+ */
+
+/**
+ * @param {import('../src/types/ucanto.js').ServiceInvoke<AccessService, AccessDelegate | AccessClaim>} invoke
  * @param {Ucanto.Signer<Ucanto.DID<'key'>>} issuer
  * @param {Ucanto.Verifier<Ucanto.DID>} audience
  */
@@ -521,31 +457,3 @@ async function setupDelegateThenClaim(invoker, audience) {
  * @typedef {Ucanto.InferInvokedCapability<typeof Access.claim>} AccessClaim
  * @typedef {Ucanto.InferInvokedCapability<typeof Access.delegate>} AccessDelegate
  */
-
-/**
- * @param {import('../src/service/access-delegate.js').AccessDelegateHandler} handleDelegate
- * @param {InvocationHandler<AccessClaim, unknown, { error: true }>} handleClaim
- * @returns {InvocationHandler<AccessDelegate | AccessClaim, unknown, { error: true }>}
- */
-function createAccessHandler(handleDelegate, handleClaim) {
-  return async (invocation) => {
-    const can = invocation.capabilities[0].can
-    switch (can) {
-      case 'access/claim': {
-        return handleClaim(
-          /** @type {Ucanto.Invocation<AccessClaim>} */ (invocation)
-        )
-      }
-      case 'access/delegate': {
-        return handleDelegate(
-          /** @type {Ucanto.Invocation<AccessDelegate>} */ (invocation)
-        )
-      }
-      default: {
-        // eslint-disable-next-line no-void
-        void (/** @type {never} */ (can))
-      }
-    }
-    throw new Error(`unexpected can=${can}`)
-  }
-}

--- a/packages/access-api/test/helpers/types.ts
+++ b/packages/access-api/test/helpers/types.ts
@@ -1,9 +1,9 @@
 import type * as Ucanto from '@ucanto/interface'
 import type { Miniflare } from 'miniflare'
 
-export interface HelperTestContext {
+export interface HelperTestContext<Service extends Record<string, any>> {
   issuer: Ucanto.Signer<Ucanto.DID<'key'>>
   service: Ucanto.Signer<Ucanto.DID<'web'>>
-  conn: Ucanto.ConnectionView<Record<string, any>>
+  conn: Ucanto.ConnectionView<Service>
   mf: Miniflare
 }

--- a/packages/access-api/test/provider-add.test.js
+++ b/packages/access-api/test/provider-add.test.js
@@ -290,13 +290,19 @@ export function createEmail(storage) {
 }
 
 /**
+ * @typedef {import('@web3-storage/capabilities/types').AccessClaim} AccessClaim
+ * @typedef {import('@web3-storage/capabilities/types').AccessAuthorize} AccessAuthorize
+ * @typedef {import('@web3-storage/capabilities/types').ProviderAdd} ProviderAdd
+ */
+
+/**
  * @param {object} options
  * @param {Ucanto.Signer<Ucanto.DID<'key'>>} options.deviceA
  * @param {Ucanto.Signer<Ucanto.DID<'key'>>} options.space
  * @param {Ucanto.Principal<Ucanto.DID<'mailto'>>} options.accountA
  * @param {Ucanto.Principal<Ucanto.DID<'web'>>} options.service - web3.storage service
  * @param {import('miniflare').Miniflare} options.miniflare
- * @param {import('../src/types/ucanto.js').ServiceInvoke<import('./helpers/ucanto-test-utils.js').AccessService>} options.invoke
+ * @param {import('../src/types/ucanto.js').ServiceInvoke<import('./helpers/ucanto-test-utils.js').AccessService, AccessClaim|AccessAuthorize|ProviderAdd>} options.invoke
  * @param {ValidationEmailSend[]} options.emails
  */
 async function testAuthorizeClaimProviderAdd(options) {

--- a/packages/access-api/test/provider-add.test.js
+++ b/packages/access-api/test/provider-add.test.js
@@ -296,7 +296,7 @@ export function createEmail(storage) {
  * @param {Ucanto.Principal<Ucanto.DID<'mailto'>>} options.accountA
  * @param {Ucanto.Principal<Ucanto.DID<'web'>>} options.service - web3.storage service
  * @param {import('miniflare').Miniflare} options.miniflare
- * @param {(invocation: Ucanto.Invocation<Ucanto.Capability>) => Promise<unknown>} options.invoke
+ * @param {import('../src/types/ucanto.js').ServiceInvoke<import('./helpers/ucanto-test-utils.js').AccessService>} options.invoke
  * @param {ValidationEmailSend[]} options.emails
  */
 async function testAuthorizeClaimProviderAdd(options) {
@@ -393,6 +393,7 @@ async function testAuthorizeClaimProviderAdd(options) {
   assertNotError(providerAddAsAccountResult)
 
   const spaceStorageResult = await options.invoke(
+    // @ts-ignore - not in service type because only enabled while testing
     await ucanto
       .invoke({
         issuer: space,


### PR DESCRIPTION
Motivation:
* there weren't any tests that test access-api + access-client agent, so this adds a stub for one
* it includes a lot of type adjustments that should make it easier to write more tests in followup
  * specifically it removed some old types I had tried to make when testing access delegate. I added a new `ServiceInvoke` type that is better than the ones I had made before. This is useful for making an 'invoke' function that will handle a subset of the caps available on `Service` but expect the same success/fail types as Service