### PR TITLE
feat: use bigger block sizes and increase max children

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@ipld/car": "^5.0.3",
     "@ipld/dag-ucan": "^3.2.0",
-    "@ipld/unixfs": "^2.1.0",
+    "@ipld/unixfs": "^2.1.1",
     "@ucanto/client": "^5.1.0",
     "@ucanto/interface": "^6.0.0",
     "@ucanto/transport": "^5.1.0",

--- a/packages/upload-client/src/unixfs.js
+++ b/packages/upload-client/src/unixfs.js
@@ -1,13 +1,16 @@
 import * as UnixFS from '@ipld/unixfs'
 import * as raw from 'multiformats/codecs/raw'
+import { withMaxChunkSize } from '@ipld/unixfs/file/chunker/fixed'
+import { withWidth } from '@ipld/unixfs/file/layout/balanced'
 
 const SHARD_THRESHOLD = 1000 // shard directory after > 1,000 items
 const queuingStrategy = UnixFS.withCapacity()
 
-// TODO: configure chunk size and max children https://github.com/ipld/js-unixfs/issues/36
 const settings = UnixFS.configure({
   fileChunkEncoder: raw,
   smallFileEncoder: raw,
+  chunker: withMaxChunkSize(1024 * 1024),
+  fileLayout: withWidth(1024),
 })
 
 /**

--- a/packages/upload-client/test/index.test.js
+++ b/packages/upload-client/test/index.test.js
@@ -113,7 +113,7 @@ describe('uploadFile', () => {
   it('allows custom shard size to be set', async () => {
     const space = await Signer.generate()
     const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const file = new Blob([await randomBytes(500_000)])
+    const file = new Blob([await randomBytes(1024 * 1024 * 5)])
     /** @type {import('../src/types').CARLink[]} */
     const carCIDs = []
 
@@ -174,12 +174,12 @@ describe('uploadFile', () => {
       file,
       {
         connection,
-        shardSize: 400_000, // should end up with 2 CAR files
+        shardSize: 1024 * 1024 * 2, // should end up with 2 CAR files
         onShardStored: (meta) => carCIDs.push(meta.cid),
       }
     )
 
-    assert.equal(carCIDs.length, 2)
+    assert.equal(carCIDs.length, 3)
   })
 })
 

--- a/packages/upload-client/test/sharding.test.js
+++ b/packages/upload-client/test/sharding.test.js
@@ -15,8 +15,8 @@ import { mockService } from './helpers/mocks.js'
 
 describe('ShardingStream', () => {
   it('creates shards from blocks', async () => {
-    const file = new Blob([await randomBytes(1024 * 1024)])
-    const shardSize = 512 * 1024
+    const file = new Blob([await randomBytes(1024 * 1024 * 5)])
+    const shardSize = 1024 * 1024 * 2
 
     /** @type {import('../src/types').CARFile[]} */
     const shards = []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
     specifiers:
       '@ipld/car': ^5.0.3
       '@ipld/dag-ucan': ^3.2.0
-      '@ipld/unixfs': ^2.1.0
+      '@ipld/unixfs': ^2.1.1
       '@types/assert': ^1.5.6
       '@types/mocha': ^10.0.1
       '@ucanto/client': ^5.1.0
@@ -353,7 +353,7 @@ importers:
     dependencies:
       '@ipld/car': 5.1.0
       '@ipld/dag-ucan': 3.2.0
-      '@ipld/unixfs': 2.1.0
+      '@ipld/unixfs': 2.1.1
       '@ucanto/client': 5.1.0
       '@ucanto/interface': 6.0.0
       '@ucanto/transport': 5.1.0
@@ -2525,8 +2525,8 @@ packages:
       '@ipld/dag-json': 10.0.1
       multiformats: 11.0.1
 
-  /@ipld/unixfs/2.1.0:
-    resolution: {integrity: sha512-il1vU83a/0QsmIvWvqoWdPgw6Uedjdryj4LsmoJKm4jEUmevMnxZTsTEHp3uzvzMJaLmUmB5ZABIvVvBQHdhmQ==}
+  /@ipld/unixfs/2.1.1:
+    resolution: {integrity: sha512-g3gr/3XvfQs4x2VFjlICae09ul5fbWCKRInN6Vgeot2+GH0h/krr3PqZCIo4dy4Ou2mQOsIddxUvG8UZ4p9SbQ==}
     dependencies:
       '@ipld/dag-pb': 4.0.2
       '@multiformats/murmur3': 2.1.3


### PR DESCRIPTION
This PR updates the UnixFS configuration to bring it in line with the [configuration used in our existing client](https://github.com/web3-storage/web3.storage/blob/main/packages/client/src/lib.js#L153-L159).

Block size is 1MB and max children per node is 1024.