### PR TITLE
feat: store spaces after claiming delegations

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -51,6 +51,10 @@ export async function claimDelegations(
     bytesToDelegations(bytes)
   )
   if (addProofs) for (const d of delegations) access.addProof(d)
+
+  // TODO get rid of this - we'd like to move responsibility for storing space metadata out of agent-data soon
+  if (addProofs) access._addSpacesFromDelegations(delegations)
+
   return delegations
 }
 

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -517,6 +517,30 @@ export class Agent {
   }
 
   /**
+   * Given a list of delegations, add to agent data spaces list.
+   *
+   * TODO: DON'T USE - we'd like to move away from storing space information inside the agent, planning on removing this soon!
+   *
+   * @param {Ucanto.Delegation<Ucanto.Capabilities>[]} delegations
+   */
+  async _addSpacesFromDelegations(delegations) {
+    if (delegations.length > 0) {
+      const allows = ucanto.Delegation.allows(
+        delegations[0],
+        ...delegations.slice(1)
+      )
+      for (const [did, value] of Object.entries(allows)) {
+        // TODO I don't think this should be `store/*` but this works for today
+        if (value['store/*']) {
+          this.#data.addSpace(/** @type {Ucanto.DID} */ (did), {
+            isRegistered: true,
+          })
+        }
+      }
+    }
+  }
+
+  /**
    * @param {Ucanto.DID<'key'>} space
    * @param {Ucanto.Principal<Ucanto.DID<'mailto'>>} account
    * @param {Ucanto.DID<'web'>} provider - e.g. 'did:web:staging.web3.storage'


### PR DESCRIPTION
some hacky logic to enable the "claim spaces on second device" flow - @bengo and I are planning on refactoring this whole API to pull spaces out of the agent but want to get it working with the current API first