### PR TITLE
fix: Agent#authorize races websocket and polling access/claim 

### DIFF
--- a/packages/access-api/test/access-client-agent.test.js
+++ b/packages/access-api/test/access-client-agent.test.js
@@ -380,7 +380,7 @@ for (const accessApiVariant of /** @type {const} */ ([
     await addSpacesFromDelegations(accessAgent, [])
   })
 
-  it.skip('multi device authorize method', async () => {
+  it('multi device authorize method', async () => {
     const abort = new AbortController()
     after(() => abort.abort())
     const account = {
@@ -388,6 +388,7 @@ for (const accessApiVariant of /** @type {const} */ ([
       did: thisEmailDidMailto,
     }
     const { connection, emails } = await accessApiVariant.create()
+    const provider = /** @type {Ucanto.DID<'web'>} */ (connection.id.did())
     const deviceA = await AccessAgent.create(undefined, {
       connection,
     })
@@ -397,9 +398,10 @@ for (const accessApiVariant of /** @type {const} */ ([
       watchForEmail(emails, 100, abort.signal).then((email) => {
         return confirmConfirmationUrl(deviceA.connection, email)
       })
-    // authorize() will hang because it tries to connect ws to localhost:8787
-    // which gets ECONNREFUSED, but ../src/ws.js swallws error
     await Promise.all([authorize(), clickNextConfirmationLink()])
+
+    const space = await deviceA.createSpace()
+    await addProvider(deviceA, space.did, account, provider)
   })
 
   it('can poll access/claim to know when confirmation happened', async () => {
@@ -432,7 +434,7 @@ for (const accessApiVariant of /** @type {const} */ ([
       authorize(),
       clickNextConfirmationLink(),
     ])
-    assert.equal(claimed.length, 2)
+    assert.equal([...claimed].length, 2)
   })
 }
 

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -164,7 +164,7 @@ const isSessionCapability = (cap) => cap.can === Access.session.can
  * @param {Ucanto.Delegation} delegation
  * @returns {delegation is Ucanto.Delegation<[import('./types').AccessSession]>}
  */
-const isSessionProof = (delegation) =>
+export const isSessionProof = (delegation) =>
   delegation.capabilities.some((cap) => isSessionCapability(cap))
 
 /**


### PR DESCRIPTION
TIL:
* the websocket definitely doesn't really work in access-api tests, because access-ws is an entirely different cf worker! it's not running in those access-api tests
* so 100% of the time the websocket immediately terminates with ECONNREFUSED, but afaict that error isn't really bubbled up when Agent calls `await ws.open`. This still doesn't bubble up that error, but does allow for that open to be abortable
* and then authorize() races that websocket and polling access claim. If access/claim polling wins, it aborts the websocket, and everything kinda maybe works

End result
* this re-enables a test against Agent#authorize, which passes due to the polling  on access/claim
  * in the wild maybe the websocket will win the race sometimes

(so it can be used in tests)