### PR TITLE
fix: set currentSpace inside addSpace if currentSpace isn't set

### DIFF
--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -111,12 +111,15 @@ export class AgentData {
 
   /**
    * @deprecated
-   * @param {import('@ucanto/interface').DID} did
+   * @param {import('@ucanto/interface').DID<'key'>} did
    * @param {import('./types').SpaceMeta} meta
    * @param {import('@ucanto/interface').Delegation} [proof]
    */
   async addSpace(did, meta, proof) {
     this.spaces.set(did, meta)
+    if (!this.currentSpace) {
+      this.currentSpace = did
+    }
     await (proof ? this.addDelegation(proof) : this.#save(this.export()))
   }
 

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -754,7 +754,7 @@ export async function addSpacesFromDelegations(access, delegations) {
 
     for (const [did, value] of Object.entries(allows)) {
       if (did.startsWith('did:key') && value['space/*']) {
-        data.addSpace(/** @type {Ucanto.DID} */ (did), {
+        data.addSpace(/** @type {Ucanto.DID<'key'>} */ (did), {
           isRegistered: true,
         })
       }


### PR DESCRIPTION
I noticed this wasn't happening because w3ui's w3console was in a state where the space picker was populated with many spaces, but currentSpace wasn't set.

I think we should avoid this situation at this level because it's most convenient for me, but open to moving this assurance to another level if.