### PR TITLE
feat: ucan invocation post handled car

### DIFF
--- a/.github/workflows/reusable-deploy-api.yml
+++ b/.github/workflows/reusable-deploy-api.yml
@@ -24,6 +24,8 @@ on:
         required: true
       LOGTAIL_TOKEN:
         required: true
+      UCAN_INVOCATION_POST_BASIC_AUTH:
+        required: true
 
 jobs:
   deploy-api:
@@ -58,6 +60,7 @@ jobs:
             PRIVATE_KEY
             SENTRY_DSN
             LOGTAIL_TOKEN
+            UCAN_INVOCATION_POST_BASIC_AUTH
         env:
           POSTMARK_TOKEN: ${{ secrets.POSTMARK_TOKEN }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
@@ -65,3 +68,4 @@ jobs:
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD }}
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
           LOGTAIL_TOKEN: ${{ secrets.LOGTAIL_TOKEN }}
+          UCAN_INVOCATION_POST_BASIC_AUTH: ${{ secrets.UCAN_INVOCATION_POST_BASIC_AUTH }}

--- a/packages/access-api/package.json
+++ b/packages/access-api/package.json
@@ -41,6 +41,7 @@
     "@cloudflare/workers-types": "^3.18.0",
     "@databases/split-sql-query": "^1.0.3",
     "@databases/sql": "^3.2.0",
+    "@miniflare/core": "^2.11.0",
     "@sentry/cli": "2.7.0",
     "@types/assert": "^1.5.6",
     "@types/git-rev-sync": "^2.0.0",

--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -72,7 +72,7 @@ export interface RouteContext {
     validations: Validations
   }
   uploadApi: ConnectionView
-  uploadApiUrl: URL
+  ucanInvocationPostURL: URL
   ucanInvocationPostBasicAuth: string
 }
 

--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -46,6 +46,7 @@ export interface Env {
   SENTRY_DSN: string
   POSTMARK_TOKEN: string
   POSTMARK_SENDER?: string
+  UCAN_INVOCATION_POST_BASIC_AUTH: string
 
   DEBUG_EMAIL?: string
   LOGTAIL_TOKEN: string
@@ -71,6 +72,8 @@ export interface RouteContext {
     validations: Validations
   }
   uploadApi: ConnectionView
+  uploadApiUrl: URL
+  ucanInvocationPostBasicAuth: string
 }
 
 export type Handler = _Handler<RouteContext>

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -43,6 +43,7 @@ export function loadConfig(env) {
     POSTMARK_SENDER: env.POSTMARK_SENDER,
     SENTRY_DSN: vars.SENTRY_DSN,
     LOGTAIL_TOKEN: vars.LOGTAIL_TOKEN,
+    UCAN_INVOCATION_POST_BASIC_AUTH: vars.UCAN_INVOCATION_POST_BASIC_AUTH,
 
     // These are injected in esbuild
     // @ts-ignore

--- a/packages/access-api/src/routes/raw.js
+++ b/packages/access-api/src/routes/raw.js
@@ -1,4 +1,5 @@
 import * as Server from '@ucanto/server'
+import pRetry from 'p-retry'
 import { serverCodec } from '../ucanto/server-codec.js'
 import { service } from '../service/index.js'
 
@@ -30,13 +31,19 @@ export async function postRaw(request, env, ctx) {
   // Process CAR with invocations asynchronously
   ctx.waitUntil(
     (async () => {
-      await fetch(new URL('/ucan', env.uploadApiUrl), {
-        method: 'POST',
-        headers: {
-          Authorization: `Basic ${env.ucanInvocationPostBasicAuth}`,
-        },
-        body,
-      })
+      await pRetry(
+        () =>
+          fetch(new URL('/ucan', env.ucanInvocationPostURL), {
+            method: 'POST',
+            headers: {
+              Authorization: `Basic ${env.ucanInvocationPostBasicAuth}`,
+            },
+            body,
+          }),
+        {
+          retries: 10,
+        }
+      )
     })()
   )
 

--- a/packages/access-api/src/routes/raw.js
+++ b/packages/access-api/src/routes/raw.js
@@ -2,11 +2,15 @@ import * as Server from '@ucanto/server'
 import { serverCodec } from '../ucanto/server-codec.js'
 import { service } from '../service/index.js'
 
+// https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent
+/** @typedef {{ waitUntil(p: Promise<any>): void }} Ctx */
+
 /**
  * @param {import('@web3-storage/worker-utils/router').ParsedRequest} request
  * @param {import('../bindings.js').RouteContext} env
+ * @param {Ctx} ctx
  */
-export async function postRaw(request, env) {
+export async function postRaw(request, env, ctx) {
   const server = Server.create({
     id: env.signer,
     encoder: serverCodec,
@@ -17,9 +21,24 @@ export async function postRaw(request, env) {
     },
   })
 
+  const body = new Uint8Array(await request.arrayBuffer())
   const rsp = await server.request({
-    body: new Uint8Array(await request.arrayBuffer()),
+    body,
     headers: Object.fromEntries(request.headers.entries()),
   })
+
+  // Process CAR with invocations asynchronously
+  ctx.waitUntil(
+    (async () => {
+      await fetch(new URL('/ucan', env.uploadApiUrl), {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${env.ucanInvocationPostBasicAuth}`,
+        },
+        body,
+      })
+    })()
+  )
+
   return new Response(rsp.body, { headers: rsp.headers })
 }

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -87,5 +87,7 @@ export function getContext(request, env, ctx) {
       url: new URL(config.UPLOAD_API_URL),
       fetch: globalThis.fetch.bind(globalThis),
     }),
+    uploadApiUrl: new URL(config.UPLOAD_API_URL),
+    ucanInvocationPostBasicAuth: config.UCAN_INVOCATION_POST_BASIC_AUTH,
   }
 }

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -87,7 +87,7 @@ export function getContext(request, env, ctx) {
       url: new URL(config.UPLOAD_API_URL),
       fetch: globalThis.fetch.bind(globalThis),
     }),
-    uploadApiUrl: new URL(config.UPLOAD_API_URL),
+    ucanInvocationPostURL: new URL(config.UPLOAD_API_URL),
     ucanInvocationPostBasicAuth: config.UCAN_INVOCATION_POST_BASIC_AUTH,
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       '@databases/split-sql-query': ^1.0.3
       '@databases/sql': ^3.2.0
       '@ipld/dag-ucan': ^3.2.0
+      '@miniflare/core': ^2.11.0
       '@sentry/cli': 2.7.0
       '@types/assert': ^1.5.6
       '@types/git-rev-sync': ^2.0.0
@@ -99,6 +100,7 @@ importers:
       '@cloudflare/workers-types': 3.19.0
       '@databases/split-sql-query': 1.0.3_@databases+sql@3.3.0
       '@databases/sql': 3.3.0
+      '@miniflare/core': 2.11.0
       '@sentry/cli': 2.7.0
       '@types/assert': 1.5.6
       '@types/git-rev-sync': 2.0.0
@@ -2880,7 +2882,7 @@ packages:
       '@miniflare/core': 2.11.0
       '@miniflare/shared': 2.11.0
       http-cache-semantics: 4.1.1
-      undici: 5.9.1
+      undici: 5.20.0
     dev: true
 
   /@miniflare/cache/2.12.1:
@@ -2921,7 +2923,7 @@ packages:
       dotenv: 10.0.0
       kleur: 4.1.5
       set-cookie-parser: 2.5.1
-      undici: 5.9.1
+      undici: 5.20.0
       urlpattern-polyfill: 4.0.3
     dev: true
 
@@ -2964,7 +2966,7 @@ packages:
       '@miniflare/core': 2.11.0
       '@miniflare/shared': 2.11.0
       '@miniflare/storage-memory': 2.11.0
-      undici: 5.9.1
+      undici: 5.20.0
     dev: true
 
   /@miniflare/durable-objects/2.12.1:
@@ -2984,7 +2986,7 @@ packages:
       '@miniflare/core': 2.11.0
       '@miniflare/shared': 2.11.0
       html-rewriter-wasm: 0.4.1
-      undici: 5.9.1
+      undici: 5.20.0
     dev: true
 
   /@miniflare/html-rewriter/2.12.1:
@@ -3006,8 +3008,8 @@ packages:
       '@miniflare/web-sockets': 2.11.0
       kleur: 4.1.5
       selfsigned: 2.1.1
-      undici: 5.9.1
-      ws: 8.12.0
+      undici: 5.20.0
+      ws: 8.13.0
       youch: 2.2.2
     transitivePeerDependencies:
       - bufferutil
@@ -3064,7 +3066,7 @@ packages:
     engines: {node: '>=16.13'}
     dependencies:
       '@miniflare/shared': 2.11.0
-      undici: 5.9.1
+      undici: 5.20.0
     dev: true
 
   /@miniflare/r2/2.12.1:
@@ -3195,8 +3197,8 @@ packages:
     dependencies:
       '@miniflare/core': 2.11.0
       '@miniflare/shared': 2.11.0
-      undici: 5.9.1
-      ws: 8.12.0
+      undici: 5.20.0
+      ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9546,7 +9548,7 @@ packages:
       kleur: 4.1.5
       semiver: 1.1.0
       source-map-support: 0.5.21
-      undici: 5.9.1
+      undici: 5.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12788,11 +12790,6 @@ packages:
       busboy: 1.6.0
     dev: true
 
-  /undici/5.9.1:
-    resolution: {integrity: sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==}
-    engines: {node: '>=12.18'}
-    dev: true
-
   /unherit/1.1.3:
     resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==}
     dependencies:
@@ -13407,7 +13404,7 @@ packages:
       blake3-wasm: 2.1.5
       chokidar: 3.5.3
       esbuild: 0.16.3
-      miniflare: 2.12.1
+      miniflare: 2.11.0
       nanoid: 3.3.4
       path-to-regexp: 6.2.1
       selfsigned: 2.1.1
@@ -13522,6 +13519,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
 
   /ws/8.13.0:
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}


### PR DESCRIPTION
Adds POST of handled CAR invocations to w3infra's https://github.com/web3-storage/w3infra/pull/171

Implementation details:
- Performed in `waitUntil`. We have no way to rollback previous operations if it fails. We should have a failure tolerance here with CF Queue. Let's create an issue and sort this out in follow up.
- Only makes sure in tests that endpoint returns 200. We need to discuss on how we should perform integration tests for this!

Note that `fetchMock` was not working with current version of `miniflare`. Upgrading miniflare creates issues with D1 which I was not able to solve easily. The issues looked to be with `undici` version behind current miniflare release. Upgraded in the lock file manually just `undici` and is now working! 

Needs:
- [x] secret set