### PR TITLE
chore: set package versions manually for now

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,9 +4,17 @@
     "packages/access-client": {
       "prerelease": true
     },
-    "packages/access-api": {},
-    "packages/capabilities": {},
-    "packages/upload-api": {},
-    "packages/upload-client": {}
+    "packages/access-api": {
+      "release-as": "5.0.0"
+    },
+    "packages/capabilities": {
+      "release-as": "4.0.1"
+    },
+    "packages/upload-api": {
+      "release-as": "2.0.0"
+    },
+    "packages/upload-client": {
+      "release-as": "8.0.0"
+    }
   }
 }


### PR DESCRIPTION
Per instructions and examples here:

https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md

Set package numbers manually for now. Release Please is currently very confused because we set a prerelease version number using a commit and now it wants to release everything with that version number. This should fix that.

After we release these packages we should be able to delete these and it will go back to guessing based on conventional commits.