### PR TITLE
fix: call claimAccess at the end of authorizeWithPollClaim

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -265,7 +265,7 @@ export async function authorizeWithPollClaim(access, email, opts) {
   })
   // Claim delegations here because we will need an ucan/attest from the service to
   // pair with the session delegation we just claimed to make it work.
-  // This is a bit duplicative because we're already invoking `access/claim` in the 
+  // This is a bit duplicative because we're already invoking `access/claim` in the
   // wait function above, but we don't do space inference there so do it one more time
   // for consistency with authorizeWithSocket.
   await claimAccess(access, access.issuer.did(), { addProofs: true })

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -263,6 +263,12 @@ export async function authorizeWithPollClaim(access, email, opts) {
     ...opts,
     expectAuthorization,
   })
+  // Claim delegations here because we will need an ucan/attest from the service to
+  // pair with the session delegation we just claimed to make it work.
+  // This is a bit duplicative because we're already invoking `access/claim` in the 
+  // wait function above, but we don't do space inference there so do it one more time
+  // for consistency with authorizeWithSocket.
+  await claimAccess(access, access.issuer.did(), { addProofs: true })
 }
 
 /**


### PR DESCRIPTION
I'm testing out using `authorizeWithPollClaim` instead of `authorizeWithSocket` to see if it will return more quickly after the email validation link is clicked and therefore better for demos. It worked, but doesn't currently run `claimDelegations` and therefore doesn't infer spaces from the list of claimed delegations.

This feels a bit duplicative because we're already executing `access/claim` several times while we poll, but one more time won't hurt much and this makes it more consistent with `authorizeWithSocket`.