### PR TITLE
chore: rename ACCESS_API_R2 binding to DELEGATIONS, and configure wranger.toml to use env-specific buckets

### DIFF
--- a/packages/access-api/src/bindings.d.ts
+++ b/packages/access-api/src/bindings.d.ts
@@ -50,10 +50,9 @@ export interface Env {
   VALIDATIONS: KVNamespace
   W3ACCESS_METRICS: AnalyticsEngine
   /**
-   * primary r2 bucket used by access-api.
    * will be used for storing env.models.delegations CARs
    */
-  ACCESS_API_R2: R2Bucket
+  DELEGATIONS: R2Bucket
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __D1_BETA__: D1Database
 }

--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -35,9 +35,9 @@ export function loadConfig(env) {
     }
   }
 
-  if (typeof env.ACCESS_API_R2 !== 'object') {
+  if (typeof env.DELEGATIONS !== 'object') {
     throw new TypeError(
-      `expected env.ACCESS_API_R2 to be an R2Bucket object, but got ${typeof env.ACCESS_API_R2}`
+      `expected env.DELEGATIONS to be an R2Bucket object, but got ${typeof env.DELEGATIONS}`
     )
   }
 
@@ -73,7 +73,7 @@ export function loadConfig(env) {
     SPACES: env.SPACES,
     VALIDATIONS: env.VALIDATIONS,
     DB: /** @type {D1Database} */ (env.__D1_BETA__),
-    ACCESS_API_R2: env.ACCESS_API_R2,
+    DELEGATIONS: env.DELEGATIONS,
   }
 }
 

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -75,7 +75,7 @@ export function getContext(request, env, ctx) {
             return delegationsTableBytesToArrayBuffer(v) ?? v
           },
         }),
-        config.ACCESS_API_R2
+        config.DELEGATIONS
       ),
       spaces: new Spaces(config.DB),
       validations: new Validations(config.VALIDATIONS),

--- a/packages/access-api/test/helpers/context.js
+++ b/packages/access-api/test/helpers/context.js
@@ -14,7 +14,7 @@ dotenv.config({
 })
 
 /**
- * @typedef {Omit<import('../../src/bindings').Env, 'SPACES'|'VALIDATIONS'|'__D1_BETA__'|'ACCESS_API_R2'>} AccessApiBindings - bindings object expected by access-api workers
+ * @typedef {Omit<import('../../src/bindings').Env, 'SPACES'|'VALIDATIONS'|'__D1_BETA__'|'DELEGATIONS'>} AccessApiBindings - bindings object expected by access-api workers
  */
 
 /**

--- a/packages/access-api/wrangler.toml
+++ b/packages/access-api/wrangler.toml
@@ -26,8 +26,8 @@ database_name = "spaces-dev"
 database_id = "7c676e0c-b9e7-4711-97c8-7b1c8eb229ae"
 
 [[r2_buckets]]
-binding = "ACCESS_API_R2"
-bucket_name = "access-api-dev-1"
+binding = "DELEGATIONS"
+bucket_name = "access-api-delegations-dev-0"
 
 [vars]
 ENV = "dev"
@@ -76,7 +76,9 @@ d1_databases = [
 unsafe = { bindings = [
     { type = "analytics_engine", dataset = "W3ACCESS_METRICS", name = "W3ACCESS_METRICS" },
 ] }
-
+[[env.staging.r2_buckets]]
+binding = "DELEGATIONS"
+bucket_name = "access-api-delegations-staging-0"
 
 # Production
 [env.production]
@@ -93,6 +95,9 @@ d1_databases = [
 unsafe = { bindings = [
     { type = "analytics_engine", dataset = "W3ACCESS_METRICS", name = "W3ACCESS_METRICS" },
 ] }
+[[env.production.r2_buckets]]
+binding = "DELEGATIONS"
+bucket_name = "access-api-delegations-prod-0"
 [env.production.vars]
 DEBUG = "false"
 DID = "did:web:web3.storage"


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/pull/578#discussion_r1145521662
* https://github.com/web3-storage/w3protocol/pull/578#discussion_r1145504659