### PR TITLE
fix: access-api utils/context no longer throws in staging and prod if UCAN configs are falsy

### DIFF
--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -36,14 +36,6 @@ export function getContext(request, env, ctx) {
           sender: config.POSTMARK_SENDER,
         })
 
-  if (['staging', 'production'].includes(config.ENV)) {
-    if (!config.UCAN_LOG_BASIC_AUTH) {
-      throw new Error(`config.UCAN_LOG_BASIC_AUTH is required but missing`)
-    }
-    if (!config.UCAN_LOG_URL) {
-      throw new Error(`config.UCAN_LOG_URL is required but missing`)
-    }
-  }
   const ucanLog =
     config.UCAN_LOG_URL && config.UCAN_LOG_BASIC_AUTH
       ? UCANLog.connect({


### PR DESCRIPTION
Motivation:
* this is no longer useful. it helped us catch another bug. https://github.com/web3-storage/w3protocol/pull/629
* now we may want to remove these configs in an env, so we don't want it to throw in that case