### PR TITLE
fix: @web3-storage/access/agent no longer exports authorizeWithPollClaim

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -9,7 +9,7 @@ import { bytesToDelegations, stringToDelegation } from './encoding.js'
 import { Provider } from '@web3-storage/capabilities'
 import * as w3caps from '@web3-storage/capabilities'
 import { Websocket, AbortError } from './utils/ws.js'
-import { AgentData, isSessionProof } from './agent-data.js'
+import { AgentData } from './agent-data.js'
 import * as ucanto from '@ucanto/core'
 import { DID as DIDValidator } from '@ucanto/validator'
 
@@ -235,34 +235,6 @@ export async function authorizeWithSocket(access, email, opts) {
   // claim delegations here because we will need an ucan/attest from the service to
   // pair with the session delegation we just claimed to make it work
   await claimAccess(access, access.issuer.did(), { addProofs: true })
-}
-
-/**
- * Request authorization of a session allowing this agent to issue UCANs
- * signed by the passed email address.
- *
- * @param {AccessAgent} access
- * @param {`${string}@${string}`} email
- * @param {object} [opts]
- * @param {AbortSignal} [opts.signal]
- * @param {Iterable<{ can: Ucanto.Ability }>} [opts.capabilities]
- */
-export async function authorizeWithPollClaim(access, email, opts) {
-  const expectAuthorization = () =>
-    expectNewClaimableDelegations(access, access.issuer.did(), {
-      abort: opts?.signal,
-    }).then((claimed) => {
-      if (![...claimed].some((d) => isSessionProof(d))) {
-        throw new Error(
-          `claimed new delegations, but none were a session proof`
-        )
-      }
-      return [...claimed]
-    })
-  await authorizeAndWait(access, email, {
-    ...opts,
-    expectAuthorization,
-  })
 }
 
 /**


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3protocol/issues/633

Note:
* this was an unintentional addition to our package exports and not an intentional addition to our public API, so this PR conventional commit message is not marked as a breaking api change
  * I notified the only person I expect to have relied on it https://github.com/web3-storage/w3protocol/pull/602#issuecomment-1482000952