### PR TITLE
feat: callback for directory entry link

### DIFF
--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -58,12 +58,12 @@ export async function uploadFile(conf, file, options = {}) {
  *
  * The issuer needs the `store/add` and `upload/add` delegated capability.
  * @param {import('./types').FileLike[]} files File data.
- * @param {import('./types').UploadOptions} [options]
+ * @param {import('./types').UploadDirectoryOptions} [options]
  */
 export async function uploadDirectory(conf, files, options = {}) {
   return await uploadBlockStream(
     conf,
-    UnixFS.createDirectoryEncoderStream(files),
+    UnixFS.createDirectoryEncoderStream(files, options),
     options
   )
 }

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -225,7 +225,8 @@ export interface UploadOptions
 }
 
 export interface UploadDirectoryOptions
-  extends UploadOptions, UnixFSDirectoryEncoderOptions {}
+  extends UploadOptions,
+    UnixFSDirectoryEncoderOptions {}
 
 export interface BlobLike {
   /**

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -17,6 +17,7 @@ import {
   UploadList,
   UploadRemove,
 } from '@web3-storage/capabilities/types'
+import * as UnixFS from '@ipld/unixfs/src/unixfs'
 
 export type {
   StoreAdd,
@@ -186,6 +187,15 @@ export interface RequestOptions extends Retryable, Abortable, Connectable {}
 
 export interface ListRequestOptions extends RequestOptions, Pageable {}
 
+export type DirectoryEntryLink = UnixFS.DirectoryEntryLink
+
+export interface UnixFSDirectoryEncoderOptions {
+  /**
+   * Callback for each time a directory entry has been fully encoded.
+   */
+  onDirectoryEntryLink?: (link: DirectoryEntryLink) => void
+}
+
 export interface ShardingOptions {
   /**
    * The target shard size. Actual size of CAR output may be bigger due to CAR
@@ -213,6 +223,9 @@ export interface UploadOptions
     ShardStoringOptions {
   onShardStored?: (meta: CARMetadata) => void
 }
+
+export interface UploadDirectoryOptions
+  extends UploadOptions, UnixFSDirectoryEncoderOptions {}
 
 export interface BlobLike {
   /**

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -191,7 +191,7 @@ export type DirectoryEntryLink = UnixFS.DirectoryEntryLink
 
 export interface UnixFSDirectoryEncoderOptions {
   /**
-   * Callback for each time a directory entry has been fully encoded.
+   * Callback for every DAG encoded directory entry, including the root.
    */
   onDirectoryEntryLink?: (link: DirectoryEntryLink) => void
 }

--- a/packages/upload-client/src/unixfs.js
+++ b/packages/upload-client/src/unixfs.js
@@ -147,7 +147,10 @@ export function createDirectoryEncoderStream(files, options) {
   const { readable, writable } = new TransformStream({}, queuingStrategy)
   const unixfsWriter = UnixFS.createWriter({ writable, settings })
   void (async () => {
-    await rootDir.finalize(unixfsWriter)
+    const link = await rootDir.finalize(unixfsWriter)
+    if (options?.onDirectoryEntryLink) {
+      options.onDirectoryEntryLink({ name: '', ...link })
+    }
     await unixfsWriter.close()
   })()
 

--- a/packages/upload-client/src/unixfs.js
+++ b/packages/upload-client/src/unixfs.js
@@ -32,7 +32,7 @@ export function createFileEncoderStream(blob) {
   /** @type {TransformStream<import('@ipld/unixfs').Block, import('@ipld/unixfs').Block>} */
   const { readable, writable } = new TransformStream({}, queuingStrategy)
   const unixfsWriter = UnixFS.createWriter({ writable, settings })
-  const fileBuilder = new UnixFsFileBuilder(blob)
+  const fileBuilder = new UnixFSFileBuilder('', blob)
   void (async () => {
     await fileBuilder.finalize(unixfsWriter)
     await unixfsWriter.close()
@@ -40,11 +40,15 @@ export function createFileEncoderStream(blob) {
   return readable
 }
 
-class UnixFsFileBuilder {
+class UnixFSFileBuilder {
   #file
 
-  /** @param {{ stream: () => ReadableStream }} file */
-  constructor(file) {
+  /**
+   * @param {string} name
+   * @param {import('./types').BlobLike} file
+   */
+  constructor(name, file) {
+    this.name = name
     this.#file = file
   }
 
@@ -63,8 +67,19 @@ class UnixFsFileBuilder {
 }
 
 class UnixFSDirectoryBuilder {
-  /** @type {Map<string, UnixFsFileBuilder | UnixFSDirectoryBuilder>} */
+  #options
+
+  /** @type {Map<string, UnixFSFileBuilder | UnixFSDirectoryBuilder>} */
   entries = new Map()
+
+  /**
+   * @param {string} name
+   * @param {import('./types').UnixFSDirectoryEncoderOptions} [options]
+   */
+  constructor(name, options) {
+    this.name = name
+    this.#options = options
+  }
 
   /** @param {import('@ipld/unixfs').View} writer */
   async finalize(writer) {
@@ -74,6 +89,10 @@ class UnixFSDirectoryBuilder {
         : UnixFS.createShardedDirectoryWriter(writer)
     for (const [name, entry] of this.entries) {
       const link = await entry.finalize(writer)
+      if (this.#options?.onDirectoryEntryLink) {
+        // @ts-expect-error
+        this.#options.onDirectoryEntryLink({ name: entry.name, ...link })
+      }
       dirWriter.set(name, link)
     }
     return await dirWriter.close()
@@ -82,10 +101,11 @@ class UnixFSDirectoryBuilder {
 
 /**
  * @param {Iterable<import('./types').FileLike>} files
+ * @param {import('./types').UnixFSDirectoryEncoderOptions} [options]
  * @returns {Promise<import('./types').UnixFSEncodeResult>}
  */
-export async function encodeDirectory(files) {
-  const readable = createDirectoryEncoderStream(files)
+export async function encodeDirectory(files, options) {
+  const readable = createDirectoryEncoderStream(files, options)
   const blocks = await collect(readable)
   // @ts-expect-error There is always a root block
   return { cid: blocks.at(-1).cid, blocks }
@@ -93,10 +113,11 @@ export async function encodeDirectory(files) {
 
 /**
  * @param {Iterable<import('./types').FileLike>} files
+ * @param {import('./types').UnixFSDirectoryEncoderOptions} [options]
  * @returns {ReadableStream<import('@ipld/unixfs').Block>}
  */
-export function createDirectoryEncoderStream(files) {
-  const rootDir = new UnixFSDirectoryBuilder()
+export function createDirectoryEncoderStream(files, options) {
+  const rootDir = new UnixFSDirectoryBuilder('', options)
 
   for (const file of files) {
     const path = file.name.split('/')
@@ -106,16 +127,17 @@ export function createDirectoryEncoderStream(files) {
     let dir = rootDir
     for (const [i, name] of path.entries()) {
       if (i === path.length - 1) {
-        dir.entries.set(name, new UnixFsFileBuilder(file))
+        dir.entries.set(name, new UnixFSFileBuilder(path.join('/'), file))
         break
       }
       let dirBuilder = dir.entries.get(name)
       if (dirBuilder == null) {
-        dirBuilder = new UnixFSDirectoryBuilder()
+        const dirName = dir === rootDir ? name : `${dir.name}/${name}`
+        dirBuilder = new UnixFSDirectoryBuilder(dirName, options)
         dir.entries.set(name, dirBuilder)
       }
       if (!(dirBuilder instanceof UnixFSDirectoryBuilder)) {
-        throw new Error(`"${name}" cannot be a file and a directory`)
+        throw new Error(`"${file.name}" cannot be a file and a directory`)
       }
       dir = dirBuilder
     }

--- a/packages/upload-client/test/unixfs.test.js
+++ b/packages/upload-client/test/unixfs.test.js
@@ -116,7 +116,6 @@ describe('UnixFS', () => {
     /** @type {import('../src/types.js').DirectoryEntryLink[]} */
     const links = []
     await encodeDirectory(files, { onDirectoryEntryLink: (l) => links.push(l) })
-    console.log(links)
     assert.equal(links.length, 4)
     assert.equal(links[0].name, 'file.txt')
     assert.equal(links[0].dagByteLength, 4)

--- a/packages/upload-client/test/unixfs.test.js
+++ b/packages/upload-client/test/unixfs.test.js
@@ -116,7 +116,8 @@ describe('UnixFS', () => {
     /** @type {import('../src/types.js').DirectoryEntryLink[]} */
     const links = []
     await encodeDirectory(files, { onDirectoryEntryLink: l => links.push(l) })
-    assert.equal(links.length, 3)
+    console.log(links)
+    assert.equal(links.length, 4)
     assert.equal(links[0].name, 'file.txt')
     assert.equal(links[0].dagByteLength, 4)
     assert.equal(
@@ -134,6 +135,12 @@ describe('UnixFS', () => {
     assert.equal(
       links[2].cid.toString(),
       'bafybeigbv3g5frjg66akpd6gwfkryqraom4nyrgtltpyoa4e7h3bhnbmti'
+    )
+    assert.equal(links[3].name, '')
+    assert.equal(links[3].dagByteLength, 173)
+    assert.equal(
+      links[3].cid.toString(),
+      'bafybeie4fxkioskwb4h7xpb5f6tbktm4vjxt7rtsqjit72jrv3ii5h26sy'
     )
   })
 })

--- a/packages/upload-client/test/unixfs.test.js
+++ b/packages/upload-client/test/unixfs.test.js
@@ -115,7 +115,7 @@ describe('UnixFS', () => {
     ]
     /** @type {import('../src/types.js').DirectoryEntryLink[]} */
     const links = []
-    await encodeDirectory(files, { onDirectoryEntryLink: l => links.push(l) })
+    await encodeDirectory(files, { onDirectoryEntryLink: (l) => links.push(l) })
     console.log(links)
     assert.equal(links.length, 4)
     assert.equal(links[0].name, 'file.txt')

--- a/packages/upload-client/test/unixfs.test.js
+++ b/packages/upload-client/test/unixfs.test.js
@@ -99,12 +99,41 @@ describe('UnixFS', () => {
         new File(['a file, not a directory'], 'file.txt'),
         new File(['a file in a file!!!'], 'file.txt/another.txt'),
       ]),
-      { message: '"file.txt" cannot be a file and a directory' }
+      { message: '"file.txt/another.txt" cannot be a file and a directory' }
     ))
 
   it('configured to use raw leaves', async () => {
     const file = new Blob(['test'])
     const { cid } = await encodeFile(file)
     assert.equal(cid.code, raw.code)
+  })
+
+  it('callback for each directory entry link', async () => {
+    const files = [
+      new File(['file'], 'file.txt'),
+      new File(['another'], '/dir/another.txt'),
+    ]
+    /** @type {import('../src/types.js').DirectoryEntryLink[]} */
+    const links = []
+    await encodeDirectory(files, { onDirectoryEntryLink: l => links.push(l) })
+    assert.equal(links.length, 3)
+    assert.equal(links[0].name, 'file.txt')
+    assert.equal(links[0].dagByteLength, 4)
+    assert.equal(
+      links[0].cid.toString(),
+      'bafkreib3tq2y6nxqumnwvu7bj4yjy7hrtcwjerxigfxzzzkd2wyzvqblqa'
+    )
+    assert.equal(links[1].name, 'dir/another.txt')
+    assert.equal(links[1].dagByteLength, 7)
+    assert.equal(
+      links[1].cid.toString(),
+      'bafkreifoisfmq3corzg6yzcxffyi55ayooxhtrw77bhp64zwbgeuq7yi4u'
+    )
+    assert.equal(links[2].name, 'dir')
+    assert.equal(links[2].dagByteLength, 66)
+    assert.equal(
+      links[2].cid.toString(),
+      'bafybeigbv3g5frjg66akpd6gwfkryqraom4nyrgtltpyoa4e7h3bhnbmti'
+    )
   })
 })


### PR DESCRIPTION
This PR adds a callback that is called when a directory entry has been encoded as a DAG. The callback recieves a parameter with the following data:

```ts
interface DirectoryEntryLink {
  /** Content Identifier */
  cid: Link
  /** Name (full path) */
  name: string
  /** Cumulative number of bytes in the target DAG, that is number of bytes in the block and all the blocks it links to. */
  dagByteLength: number
}
```

You'd use it like:

```js
client.uploadDirectory(conf, files, { onDirectoryEntryLink: l => console.log(l) })
```

This allows users to easily discover the CID and (DAG) size of all the files and directories within a directory as well as the root directory.

Specifically, thirdweb are uploading files separately and want to later tie them all together in a directory. For that they need to know the DAG size of each of the entries.