### PR TITLE
chore: update release-please-config.json so w3up-client has release-as 5.2.0

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,6 +6,8 @@
     "packages/capabilities": {},
     "packages/upload-api": {},
     "packages/upload-client": {},
-    "packages/w3up-client": {}
+    "packages/w3up-client": {
+      "release-as": "5.2.0"
+    }
   }
 }


### PR DESCRIPTION
Motivation:
* instruct release-please what the w3up-client version number should be so it doesn't try 11.0.x