### PR TITLE
feat: expose `onDirectoryEntryLink` option

### DIFF
--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -57,7 +57,7 @@ export class Client extends Base {
    * paths in file names preserved.
    *
    * @param {import('./types').FileLike[]} files File data.
-   * @param {import('./types').UploadOptions} [options]
+   * @param {import('./types').UploadDirectoryOptions} [options]
    */
   async uploadDirectory (files, options = {}) {
     const conf = await this._invocationConfig([StoreCapabilities.add.can, UploadCapabilities.add.can])

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -77,6 +77,7 @@ export type {
   ShardingOptions,
   ShardStoringOptions,
   UploadOptions,
+  UploadDirectoryOptions,
   FileLike,
   BlobLike
 } from '@web3-storage/upload-client/types'


### PR DESCRIPTION
Exposes the `onDirectoryEntryLink` option from https://github.com/web3-storage/w3protocol/pull/657 in `w3up-client`.