### PR TITLE
chore: remove release-as for w3up-client in release-please-config.json

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,8 +6,6 @@
     "packages/capabilities": {},
     "packages/upload-api": {},
     "packages/upload-client": {},
-    "packages/w3up-client": {
-      "release-as": "5.2.0"
-    }
+    "packages/w3up-client": {}
   }
 }


### PR DESCRIPTION
Motivation:
* we don't need this now that 5.2.0 was released
* planned followup to https://github.com/web3-storage/w3protocol/pull/662 (which was required to get release-please-action to detect the right next release number in a new repo)