### PR TITLE
chore: update w3up-client linter

### DIFF
--- a/packages/w3up-client/.github/actions/test/action.yml
+++ b/packages/w3up-client/.github/actions/test/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'path to directory of w3up-client package'
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - run: npm run lint
       shell: bash

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -58,7 +58,7 @@
     "dist"
   ],
   "scripts": {
-    "lint": "standard",
+    "lint": "tsc --build && eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
     "build": "tsc --build",
     "prepare": "npm run build",
     "test": "npm-run-all -p -r mock test:all",
@@ -89,6 +89,7 @@
     "assert": "^2.0.0",
     "c8": "^7.13.0",
     "docusaurus-plugin-typedoc": "^0.18.0",
+    "hd-scripts": "^5.0.0",
     "hundreds": "^0.0.9",
     "mocha": "^10.1.0",
     "multiformats": "^11.0.0",
@@ -99,6 +100,48 @@
     "typedoc-plugin-markdown": "^3.14.0",
     "typedoc-plugin-missing-exports": "^1.0.0",
     "typescript": "^4.8.3"
+  },
+  "eslintConfig": {
+    "extends": [
+      "./node_modules/hd-scripts/eslint/index.js"
+    ],
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "rules": {
+      "unicorn/prefer-number-properties": "off",
+      "unicorn/prefer-export-from": "off",
+      "unicorn/no-array-reduce": "off",
+      "unicorn/no-null": "off",
+      "unicorn/no-await-expression-member": "off",
+      "import/extensions": "off",
+      "jsdoc/check-tag-names": "off",
+      "jsdoc/no-undefined-types": [
+        "error",
+        {
+          "definedTypes": [
+            "ArrayLike",
+            "AsyncIterable",
+            "AsyncIterableIterator",
+            "BlobPart",
+            "Iterable",
+            "IterableIterator",
+            "Generator",
+            "CryptoKeyPair",
+            "NodeJS",
+            "ErrorOptions",
+            "IDBTransactionMode"
+          ]
+        }
+      ]
+    },
+    "env": {
+      "mocha": true
+    },
+    "ignorePatterns": [
+      "dist",
+      "coverage"
+    ]
   },
   "directories": {
     "test": "test"

--- a/packages/w3up-client/src/base.js
+++ b/packages/w3up-client/src/base.js
@@ -19,13 +19,13 @@ export class Base {
    * @param {object} [options]
    * @param {import('./types').ServiceConf} [options.serviceConf]
    */
-  constructor (agentData, options = {}) {
+  constructor(agentData, options = {}) {
     this._serviceConf = options.serviceConf ?? serviceConf
     this._agent = new Agent(agentData, {
       servicePrincipal: this._serviceConf.access.id,
       // @ts-expect-error I know but it will be HTTP for the forseeable.
       url: this._serviceConf.access.channel.url,
-      connection: this._serviceConf.access
+      connection: this._serviceConf.access,
     })
   }
 
@@ -33,13 +33,17 @@ export class Base {
    * @protected
    * @param {import('./types').Ability[]} abilities
    */
-  async _invocationConfig (abilities) {
+  async _invocationConfig(abilities) {
     const resource = this._agent.currentSpace()
     if (!resource) {
-      throw new Error('missing current space: use createSpace() or setCurrentSpace()')
+      throw new Error(
+        'missing current space: use createSpace() or setCurrentSpace()'
+      )
     }
     const issuer = this._agent.issuer
-    const proofs = await this._agent.proofs(abilities.map(can => ({ can, with: resource })))
+    const proofs = await this._agent.proofs(
+      abilities.map((can) => ({ can, with: resource }))
+    )
     const audience = this._serviceConf.upload.id
     return { issuer, with: resource, proofs, audience }
   }

--- a/packages/w3up-client/src/capability/access.js
+++ b/packages/w3up-client/src/capability/access.js
@@ -14,7 +14,7 @@ export class AccessClient extends Base {
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
    */
-  async authorize (email, options) {
+  async authorize(email, options) {
     return authorizeWithSocket(this._agent, email, options)
   }
   /* c8 ignore stop */
@@ -22,7 +22,9 @@ export class AccessClient extends Base {
   /**
    * Claim delegations granted to the account associated with this agent.
    */
-  async claim () {
-    return claimAccess(this._agent, this._agent.issuer.did(), { addProofs: true })
+  async claim() {
+    return claimAccess(this._agent, this._agent.issuer.did(), {
+      addProofs: true,
+    })
   }
 }

--- a/packages/w3up-client/src/capability/space.js
+++ b/packages/w3up-client/src/capability/space.js
@@ -7,19 +7,19 @@ export class SpaceClient extends Base {
   /**
    * Get information about a space.
    *
-   * @param {import('../types').DID} space DID of the space to retrieve info about.
+   * @param {import('../types').DID} space - DID of the space to retrieve info about.
    */
-  async info (space) {
+  async info(space) {
     return await this._agent.getSpaceInfo(space)
   }
 
   /**
    * Recover the current space.
    *
-   * @param {string} email Email address to send recovery emaail to.
+   * @param {string} email - Email address to send recovery emaail to.
    */
   /* c8 ignore next 3 */
-  async recover (email) {
+  async recover(email) {
     return await this._agent.recover(email)
   }
 }

--- a/packages/w3up-client/src/capability/store.js
+++ b/packages/w3up-client/src/capability/store.js
@@ -9,10 +9,10 @@ export class StoreClient extends Base {
   /**
    * Store a DAG encoded as a CAR file.
    *
-   * @param {Blob} car CAR file data.
+   * @param {Blob} car - CAR file data.
    * @param {import('../types').RequestOptions} [options]
    */
-  async add (car, options = {}) {
+  async add(car, options = {}) {
     const conf = await this._invocationConfig([StoreCapabilities.add.can])
     options.connection = this._serviceConf.upload
     return Store.add(conf, car, options)
@@ -23,7 +23,7 @@ export class StoreClient extends Base {
    *
    * @param {import('../types').ListRequestOptions} [options]
    */
-  async list (options = {}) {
+  async list(options = {}) {
     const conf = await this._invocationConfig([StoreCapabilities.add.can])
     options.connection = this._serviceConf.upload
     return Store.list(conf, options)
@@ -32,10 +32,10 @@ export class StoreClient extends Base {
   /**
    * Remove a stored CAR file by CAR CID.
    *
-   * @param {import('../types').CARLink} link CID of CAR file to remove.
+   * @param {import('../types').CARLink} link - CID of CAR file to remove.
    * @param {import('../types').RequestOptions} [options]
    */
-  async remove (link, options = {}) {
+  async remove(link, options = {}) {
     const conf = await this._invocationConfig([StoreCapabilities.remove.can])
     options.connection = this._serviceConf.upload
     return Store.remove(conf, link, options)

--- a/packages/w3up-client/src/capability/upload.js
+++ b/packages/w3up-client/src/capability/upload.js
@@ -9,11 +9,11 @@ export class UploadClient extends Base {
   /**
    * Register an "upload" to the resource.
    *
-   * @param {import('../types').UnknownLink} root Root data CID for the DAG that was stored.
-   * @param {import('../types').CARLink[]} shards CIDs of CAR files that contain the DAG.
+   * @param {import('../types').UnknownLink} root - Root data CID for the DAG that was stored.
+   * @param {import('../types').CARLink[]} shards - CIDs of CAR files that contain the DAG.
    * @param {import('../types').RequestOptions} [options]
    */
-  async add (root, shards, options = {}) {
+  async add(root, shards, options = {}) {
     const conf = await this._invocationConfig([UploadCapabilities.add.can])
     options.connection = this._serviceConf.upload
     return Upload.add(conf, root, shards, options)
@@ -24,7 +24,7 @@ export class UploadClient extends Base {
    *
    * @param {import('../types').ListRequestOptions} [options]
    */
-  async list (options = {}) {
+  async list(options = {}) {
     const conf = await this._invocationConfig([UploadCapabilities.list.can])
     options.connection = this._serviceConf.upload
     return Upload.list(conf, options)
@@ -33,10 +33,10 @@ export class UploadClient extends Base {
   /**
    * Remove an upload by root data CID.
    *
-   * @param {import('../types').UnknownLink} root Root data CID to remove.
+   * @param {import('../types').UnknownLink} root - Root data CID to remove.
    * @param {import('../types').RequestOptions} [options]
    */
-  async remove (root, options = {}) {
+  async remove(root, options = {}) {
     const conf = await this._invocationConfig([UploadCapabilities.remove.can])
     options.connection = this._serviceConf.upload
     return Upload.remove(conf, root, options)

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -1,5 +1,12 @@
-import { uploadFile, uploadDirectory, uploadCAR } from '@web3-storage/upload-client'
-import { Store as StoreCapabilities, Upload as UploadCapabilities } from '@web3-storage/capabilities'
+import {
+  uploadFile,
+  uploadDirectory,
+  uploadCAR,
+} from '@web3-storage/upload-client'
+import {
+  Store as StoreCapabilities,
+  Upload as UploadCapabilities,
+} from '@web3-storage/capabilities'
 import { Base } from './base.js'
 import { Space } from './space.js'
 import { Delegation as AgentDelegation } from './delegation.js'
@@ -14,13 +21,13 @@ export class Client extends Base {
    * @param {object} [options]
    * @param {import('./types').ServiceConf} [options.serviceConf]
    */
-  constructor (agentData, options) {
+  constructor(agentData, options) {
     super(agentData, options)
     this.capability = {
       access: new AccessClient(agentData, options),
       store: new StoreClient(agentData, options),
       upload: new UploadClient(agentData, options),
-      space: new SpaceClient(agentData, options)
+      space: new SpaceClient(agentData, options),
     }
   }
 
@@ -33,7 +40,7 @@ export class Client extends Base {
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
    */
-  async authorize (email, options) {
+  async authorize(email, options) {
     await this.capability.access.authorize(email, options)
   }
   /* c8 ignore stop */
@@ -42,11 +49,14 @@ export class Client extends Base {
    * Uploads a file to the service and returns the root data CID for the
    * generated DAG.
    *
-   * @param {import('./types').BlobLike} file File data.
+   * @param {import('./types').BlobLike} file - File data.
    * @param {import('./types').UploadOptions} [options]
    */
-  async uploadFile (file, options = {}) {
-    const conf = await this._invocationConfig([StoreCapabilities.add.can, UploadCapabilities.add.can])
+  async uploadFile(file, options = {}) {
+    const conf = await this._invocationConfig([
+      StoreCapabilities.add.can,
+      UploadCapabilities.add.can,
+    ])
     options.connection = this._serviceConf.upload
     return uploadFile(conf, file, options)
   }
@@ -56,11 +66,14 @@ export class Client extends Base {
    * for the generated DAG. All files are added to a container directory, with
    * paths in file names preserved.
    *
-   * @param {import('./types').FileLike[]} files File data.
+   * @param {import('./types').FileLike[]} files - File data.
    * @param {import('./types').UploadDirectoryOptions} [options]
    */
-  async uploadDirectory (files, options = {}) {
-    const conf = await this._invocationConfig([StoreCapabilities.add.can, UploadCapabilities.add.can])
+  async uploadDirectory(files, options = {}) {
+    const conf = await this._invocationConfig([
+      StoreCapabilities.add.can,
+      UploadCapabilities.add.can,
+    ])
     options.connection = this._serviceConf.upload
     return uploadDirectory(conf, files, options)
   }
@@ -74,11 +87,14 @@ export class Client extends Base {
    *
    * Use the `onShardStored` callback to obtain the CIDs of the CAR file shards.
    *
-   * @param {import('./types').BlobLike} car CAR file.
+   * @param {import('./types').BlobLike} car - CAR file.
    * @param {import('./types').UploadOptions} [options]
    */
-  async uploadCAR (car, options = {}) {
-    const conf = await this._invocationConfig([StoreCapabilities.add.can, UploadCapabilities.add.can])
+  async uploadCAR(car, options = {}) {
+    const conf = await this._invocationConfig([
+      StoreCapabilities.add.can,
+      UploadCapabilities.add.can,
+    ])
     options.connection = this._serviceConf.upload
     return uploadCAR(conf, car, options)
   }
@@ -86,21 +102,21 @@ export class Client extends Base {
   /**
    * Return the default provider.
    */
-  defaultProvider () {
+  defaultProvider() {
     return this._agent.connection.id.did()
   }
 
   /**
    * The current user agent (this device).
    */
-  agent () {
+  agent() {
     return this._agent.issuer
   }
 
   /**
    * The current space.
    */
-  currentSpace () {
+  currentSpace() {
     const did = this._agent.currentSpace()
     return did ? new Space(did, this._agent.spaces.get(did)) : undefined
   }
@@ -110,14 +126,14 @@ export class Client extends Base {
    *
    * @param {import('./types').DID<'key'>} did
    */
-  async setCurrentSpace (did) {
+  async setCurrentSpace(did) {
     await this._agent.setCurrentSpace(did)
   }
 
   /**
    * Spaces available to this agent.
    */
-  spaces () {
+  spaces() {
     return [...this._agent.spaces].map(([did, meta]) => new Space(did, meta))
   }
 
@@ -126,7 +142,7 @@ export class Client extends Base {
    *
    * @param {string} [name]
    */
-  async createSpace (name) {
+  async createSpace(name) {
     const { did, meta } = await this._agent.createSpace(name)
     return new Space(did, meta)
   }
@@ -140,8 +156,10 @@ export class Client extends Base {
    * @param {import('./types').DID<'web'>} [options.provider]
    * @param {AbortSignal} [options.signal]
    */
-  async registerSpace (email, options = {}) {
-    options.provider = options.provider ?? /** @type {import('./types').DID<'web'>} */(this.defaultProvider())
+  async registerSpace(email, options = {}) {
+    options.provider =
+      options.provider ??
+      /** @type {import('./types').DID<'web'>} */ (this.defaultProvider())
     await this._agent.registerSpace(email, options)
   }
   /* c8 ignore stop */
@@ -151,7 +169,7 @@ export class Client extends Base {
    *
    * @param {import('./types').Delegation} proof
    */
-  async addSpace (proof) {
+  async addSpace(proof) {
     const { did, meta } = await this._agent.importSpaceFromDelegation(proof)
     return new Space(did, meta)
   }
@@ -161,10 +179,10 @@ export class Client extends Base {
    *
    * Proofs are delegations with an _audience_ matching the agent DID.
    *
-   * @param {import('./types').Capability[]} [caps] Capabilities to
+   * @param {import('./types').Capability[]} [caps] - Capabilities to
    * filter by. Empty or undefined caps with return all the proofs.
    */
-  proofs (caps) {
+  proofs(caps) {
     return this._agent.proofs(caps)
   }
 
@@ -174,20 +192,22 @@ export class Client extends Base {
    *
    * @param {import('./types').Delegation} proof
    */
-  async addProof (proof) {
+  async addProof(proof) {
     await this._agent.addProof(proof)
   }
 
   /**
    * Get delegations created by the agent for others.
    *
-   * @param {import('./types').Capability[]} [caps] Capabilities to
+   * @param {import('./types').Capability[]} [caps] - Capabilities to
    * filter by. Empty or undefined caps with return all the delegations.
    */
-  delegations (caps) {
+  delegations(caps) {
     const delegations = []
     for (const { delegation, meta } of this._agent.delegationsWithMeta(caps)) {
-      delegations.push(new AgentDelegation(delegation.root, delegation.blocks, meta))
+      delegations.push(
+        new AgentDelegation(delegation.root, delegation.blocks, meta)
+      )
     }
     return delegations
   }
@@ -200,13 +220,16 @@ export class Client extends Base {
    * @param {import('./types').Abilities[]} abilities
    * @param {Omit<import('./types').UCANOptions, 'audience'> & { audienceMeta?: import('./types').AgentMeta }} [options]
    */
-  async createDelegation (audience, abilities, options = {}) {
-    const audienceMeta = options.audienceMeta ?? { name: 'agent', type: 'device' }
+  async createDelegation(audience, abilities, options = {}) {
+    const audienceMeta = options.audienceMeta ?? {
+      name: 'agent',
+      type: 'device',
+    }
     const { root, blocks } = await this._agent.delegate({
       ...options,
       abilities,
       audience,
-      audienceMeta
+      audienceMeta,
     })
     return new AgentDelegation(root, blocks, { audience: audienceMeta })
   }

--- a/packages/w3up-client/src/delegation.js
+++ b/packages/w3up-client/src/delegation.js
@@ -13,7 +13,7 @@ export class Delegation extends CoreDelegation {
    * @param {Map<string, import('./types').Block>} [blocks]
    * @param {Record<string, any>} [meta]
    */
-  constructor (root, blocks, meta = {}) {
+  constructor(root, blocks, meta = {}) {
     super(root, blocks)
     this.#meta = meta
   }
@@ -21,7 +21,7 @@ export class Delegation extends CoreDelegation {
   /**
    * User defined delegation metadata.
    */
-  meta () {
+  meta() {
     return this.#meta
   }
 }

--- a/packages/w3up-client/src/index.js
+++ b/packages/w3up-client/src/index.js
@@ -24,7 +24,7 @@ import { Client } from './client.js'
  *
  * @type {import('./types').ClientFactory}
  */
-export async function create (options = {}) {
+export async function create(options = {}) {
   const store = options.store ?? new StoreIndexedDB('w3up-client')
   const raw = await store.load()
   if (raw) return new Client(AgentData.fromExport(raw, { store }), options)

--- a/packages/w3up-client/src/index.node.js
+++ b/packages/w3up-client/src/index.node.js
@@ -21,7 +21,7 @@ import { Client } from './client.js'
  *
  * @type {import('./types').ClientFactory}
  */
-export async function create (options = {}) {
+export async function create(options = {}) {
   const store = options.store ?? new StoreConf({ profile: 'w3up-client' })
   const raw = await store.load()
   if (raw) return new Client(AgentData.fromExport(raw, { store }), options)

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -11,8 +11,8 @@ export const accessServiceConnection = connect({
   decoder: CBOR,
   channel: HTTP.open({
     url: accessServiceURL,
-    method: 'POST'
-  })
+    method: 'POST',
+  }),
 })
 
 export const uploadServiceURL = new URL('https://up.web3.storage')
@@ -24,12 +24,12 @@ export const uploadServiceConnection = connect({
   decoder: CBOR,
   channel: HTTP.open({
     url: uploadServiceURL,
-    method: 'POST'
-  })
+    method: 'POST',
+  }),
 })
 
 /** @type {import('./types').ServiceConf} */
 export const serviceConf = {
   access: accessServiceConnection,
-  upload: uploadServiceConnection
+  upload: uploadServiceConnection,
 }

--- a/packages/w3up-client/src/space.js
+++ b/packages/w3up-client/src/space.js
@@ -8,7 +8,7 @@ export class Space {
    * @param {import('./types').DID} did
    * @param {Record<string, any>} meta
    */
-  constructor (did, meta = {}) {
+  constructor(did, meta = {}) {
     this.#did = did
     this.#meta = meta
   }
@@ -16,28 +16,28 @@ export class Space {
   /**
    * The given space name.
    */
-  name () {
+  name() {
     return this.#meta.name
   }
 
   /**
    * The DID of the space.
    */
-  did () {
+  did() {
     return this.#did
   }
 
   /**
    * Whether the space has been registered with the service.
    */
-  registered () {
+  registered() {
     return Boolean(this.#meta.isRegistered)
   }
 
   /**
    * User defined space metadata.
    */
-  meta () {
+  meta() {
     return this.#meta
   }
 }

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -1,8 +1,11 @@
-import { Driver } from '@web3-storage/access/drivers/types'
-import { Service as AccessService, AgentDataExport } from '@web3-storage/access/types'
-import { Service as UploadService } from '@web3-storage/upload-client/types'
-import { ConnectionView } from '@ucanto/interface'
-import { Client } from './client'
+import { type Driver } from '@web3-storage/access/drivers/types'
+import {
+  type Service as AccessService,
+  type AgentDataExport,
+} from '@web3-storage/access/types'
+import { type Service as UploadService } from '@web3-storage/upload-client/types'
+import { type ConnectionView } from '@ucanto/interface'
+import { type Client } from './client'
 
 export interface ServiceConf {
   access: ConnectionView<AccessService>
@@ -20,15 +23,13 @@ export interface ClientFactoryOptions {
   serviceConf?: ServiceConf
 }
 
-export interface ClientFactory {
-  (options?: ClientFactoryOptions): Promise<Client>
-}
+export type ClientFactory = (options?: ClientFactoryOptions) => Promise<Client>
 
 export { Client } from './client'
 
 export type { UnknownLink } from 'multiformats'
 
-export type { 
+export type {
   DID,
   Principal,
   Delegation,
@@ -38,7 +39,7 @@ export type {
   UCANOptions,
   UCANBlock,
   Block,
-  ConnectionView
+  ConnectionView,
 } from '@ucanto/interface'
 
 export type {
@@ -55,7 +56,7 @@ export type {
   AgentDataModel,
   AgentDataExport,
   AgentMeta,
-  DelegationMeta
+  DelegationMeta,
 } from '@web3-storage/access/types'
 
 export type {
@@ -79,5 +80,5 @@ export type {
   UploadOptions,
   UploadDirectoryOptions,
   FileLike,
-  BlobLike
+  BlobLike,
 } from '@web3-storage/upload-client/types'

--- a/packages/w3up-client/test/capability/access.test.js
+++ b/packages/w3up-client/test/capability/access.test.js
@@ -19,23 +19,22 @@ describe('AccessClient', () => {
             const invCap = invocation.capabilities[0]
             assert.equal(invCap.can, AccessCapabilities.claim.can)
             return {
-              delegations: []
+              delegations: [],
             }
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const delegations = await alice.capability.access.claim()
 

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -25,23 +25,22 @@ describe('SpaceClient', () => {
               email: 'mailto:alice@example.com',
               product: 'product:test',
               updated_at: '',
-              inserted_at: ''
+              inserted_at: '',
             }
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/store.test.js
+++ b/packages/w3up-client/test/capability/store.test.js
@@ -23,23 +23,22 @@ describe('StoreClient', () => {
             return {
               status: 'upload',
               headers: { 'x-test': 'true' },
-              url: 'http://localhost:9200'
+              url: 'http://localhost:9200',
             }
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
@@ -63,9 +62,9 @@ describe('StoreClient', () => {
         results: [
           {
             link: (await randomCAR(128)).cid,
-            size: 123
-          }
-        ]
+            size: 123,
+          },
+        ],
       }
 
       const service = mockService({
@@ -77,21 +76,20 @@ describe('StoreClient', () => {
             assert.equal(invCap.can, StoreCapabilities.list.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
             return page
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
@@ -102,7 +100,10 @@ describe('StoreClient', () => {
       assert.equal(service.store.list.callCount, 1)
 
       assert.equal(res.cursor, cursor)
-      assert.equal(res.results[0].link.toString(), page.results[0].link.toString())
+      assert.equal(
+        res.results[0].link.toString(),
+        page.results[0].link.toString()
+      )
     })
   })
 
@@ -117,21 +118,20 @@ describe('StoreClient', () => {
             assert.equal(invCap.can, StoreCapabilities.remove.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
             return null
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -16,7 +16,7 @@ describe('StoreClient', () => {
 
       const res = {
         root: car.roots[0],
-        shards: [car.cid]
+        shards: [car.cid],
       }
 
       const service = mockService({
@@ -31,21 +31,20 @@ describe('StoreClient', () => {
             assert.equal(invCap.nb?.shards?.length, 1)
             assert.equal(String(invCap.nb?.shards?.[0]), car.cid.toString())
             return res
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
@@ -67,9 +66,9 @@ describe('StoreClient', () => {
         results: [
           {
             root: car.roots[0],
-            shards: [car.cid]
-          }
-        ]
+            shards: [car.cid],
+          },
+        ],
       }
 
       const service = mockService({
@@ -81,21 +80,20 @@ describe('StoreClient', () => {
             assert.equal(invCap.can, UploadCapabilities.list.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
             return page
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
@@ -106,7 +104,10 @@ describe('StoreClient', () => {
       assert.equal(service.upload.list.callCount, 1)
 
       assert.equal(res.cursor, cursor)
-      assert.equal(res.results[0].root.toString(), page.results[0].root.toString())
+      assert.equal(
+        res.results[0].root.toString(),
+        page.results[0].root.toString()
+      )
     })
   })
 
@@ -121,21 +122,20 @@ describe('StoreClient', () => {
             assert.equal(invCap.can, UploadCapabilities.remove.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
             return null
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -33,9 +33,9 @@ describe('Client', () => {
             return {
               status: 'upload',
               headers: { 'x-test': 'true' },
-              url: 'http://localhost:9200'
+              url: 'http://localhost:9200',
             }
-          })
+          }),
         },
         upload: {
           add: provide(UploadCapabilities.add, ({ invocation }) => {
@@ -48,29 +48,30 @@ describe('Client', () => {
             assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
             return {
               root: expectedCar.roots[0],
-              shards: [expectedCar.cid]
+              shards: [expectedCar.cid],
             }
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
 
       const dataCID = await alice.uploadFile(file, {
-        onShardStored: meta => { carCID = meta.cid }
+        onShardStored: (meta) => {
+          carCID = meta.cid
+        },
       })
 
       assert(service.store.add.called)
@@ -88,7 +89,10 @@ describe('Client', () => {
       const bytes = await randomBytes(128)
       const file = new Blob([bytes])
 
-      await assert.rejects(alice.uploadFile(file), { message: 'missing current space: use createSpace() or setCurrentSpace()' })
+      await assert.rejects(alice.uploadFile(file), {
+        message:
+          'missing current space: use createSpace() or setCurrentSpace()',
+      })
     })
   })
 
@@ -96,7 +100,7 @@ describe('Client', () => {
     it('should upload a directory to the service', async () => {
       const files = [
         new File([await randomBytes(128)], '1.txt'),
-        new File([await randomBytes(32)], '2.txt')
+        new File([await randomBytes(32)], '2.txt'),
       ]
 
       /** @type {import('@web3-storage/upload-client/types').CARLink|undefined} */
@@ -113,9 +117,9 @@ describe('Client', () => {
             return {
               status: 'upload',
               headers: { 'x-test': 'true' },
-              url: 'http://localhost:9200'
+              url: 'http://localhost:9200',
             }
-          })
+          }),
         },
         upload: {
           add: provide(UploadCapabilities.add, ({ invocation }) => {
@@ -127,27 +131,28 @@ describe('Client', () => {
             assert.equal(invCap.nb?.shards?.length, 1)
             if (!invCap.nb) throw new Error('nb must be present')
             return invCap.nb
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
 
       const dataCID = await alice.uploadDirectory(files, {
-        onShardStored: meta => { carCID = meta.cid }
+        onShardStored: (meta) => {
+          carCID = meta.cid
+        },
       })
 
       assert(service.store.add.called)
@@ -178,9 +183,9 @@ describe('Client', () => {
             return {
               status: 'upload',
               headers: { 'x-test': 'true' },
-              url: 'http://localhost:9200'
+              url: 'http://localhost:9200',
             }
-          })
+          }),
         },
         upload: {
           add: provide(UploadCapabilities.add, ({ invocation }) => {
@@ -193,25 +198,28 @@ describe('Client', () => {
             assert.equal(invCap.nb.shards?.length, 1)
             assert.equal(invCap.nb.shards[0].toString(), carCID.toString())
             return invCap.nb
-          })
-        }
+          }),
+        },
       })
 
       const server = createServer({
         id: await Signer.generate(),
         service,
         decoder: CAR,
-        encoder: CBOR
+        encoder: CBOR,
       })
 
-      const alice = new Client(
-        await AgentData.create(),
-        { serviceConf: await mockServiceConf(server) }
-      )
+      const alice = new Client(await AgentData.create(), {
+        serviceConf: await mockServiceConf(server),
+      })
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
-      await alice.uploadCAR(car, { onShardStored: meta => { carCID = meta.cid } })
+      await alice.uploadCAR(car, {
+        onShardStored: (meta) => {
+          carCID = meta.cid
+        },
+      })
 
       assert(service.store.add.called)
       assert.equal(service.store.add.callCount, 1)
@@ -228,7 +236,7 @@ describe('Client', () => {
       const alice = new Client(await AgentData.create())
 
       const current0 = alice.currentSpace()
-      assert(current0 == null)
+      assert(current0 === undefined)
 
       const space = await alice.createSpace()
       await alice.setCurrentSpace(space.did())
@@ -298,7 +306,7 @@ describe('Client', () => {
       await alice.setCurrentSpace(space.did())
       const name = `delegation-${Date.now()}`
       const delegation = await alice.createDelegation(bob.agent(), ['*'], {
-        audienceMeta: { type: 'device', name }
+        audienceMeta: { type: 'device', name },
       })
 
       const delegations = alice.delegations()

--- a/packages/w3up-client/test/helpers/bucket-server.js
+++ b/packages/w3up-client/test/helpers/bucket-server.js
@@ -12,4 +12,5 @@ const server = createServer((req, res) => {
   res.end()
 })
 
+// eslint-disable-next-line no-console
 server.listen(port, () => console.log(`Listening on :${port}`))

--- a/packages/w3up-client/test/helpers/car.js
+++ b/packages/w3up-client/test/helpers/car.js
@@ -7,7 +7,7 @@ import * as CAR from '@ucanto/transport/car'
 /**
  * @param {Uint8Array} bytes
  **/
-export async function toCAR (bytes) {
+export async function toCAR(bytes) {
   const hash = await sha256.digest(bytes)
   const root = CID.create(1, raw.code, hash)
 

--- a/packages/w3up-client/test/helpers/mocks.js
+++ b/packages/w3up-client/test/helpers/mocks.js
@@ -9,36 +9,38 @@ const notImplemented = () => {
 
 /**
  * @param {Partial<{
- *   store: Partial<import('@web3-storage/upload-client/types').Service['store']>
- *   upload: Partial<import('@web3-storage/upload-client/types').Service['upload']>
- *   voucher: Partial<import('@web3-storage/access/types').Service['voucher']>
- *   space: Partial<import('@web3-storage/access/types').Service['space']>
+ * store: Partial<import('@web3-storage/upload-client/types').Service['store']>
+ * upload: Partial<import('@web3-storage/upload-client/types').Service['upload']>
+ * voucher: Partial<import('@web3-storage/access/types').Service['voucher']>
+ * space: Partial<import('@web3-storage/access/types').Service['space']>
  * }>} impl
  */
-export function mockService (impl) {
+export function mockService(impl) {
   return {
     store: {
       add: withCallCount(impl.store?.add ?? notImplemented),
       list: withCallCount(impl.store?.list ?? notImplemented),
-      remove: withCallCount(impl.store?.remove ?? notImplemented)
+      remove: withCallCount(impl.store?.remove ?? notImplemented),
     },
     upload: {
       add: withCallCount(impl.upload?.add ?? notImplemented),
       list: withCallCount(impl.upload?.list ?? notImplemented),
-      remove: withCallCount(impl.upload?.remove ?? notImplemented)
+      remove: withCallCount(impl.upload?.remove ?? notImplemented),
     },
     space: {
       info: withCallCount(impl.space?.info ?? notImplemented),
-      'recover-validation': withCallCount(impl.space?.['recover-validation'] ?? notImplemented)
+      'recover-validation': withCallCount(
+        impl.space?.['recover-validation'] ?? notImplemented
+      ),
     },
     access: {
       claim: withCallCount(impl.access?.claim ?? notImplemented),
       authorize: withCallCount(impl.access?.authorize ?? notImplemented),
-      delegate: withCallCount(impl.access?.delegate ?? notImplemented)
+      delegate: withCallCount(impl.access?.delegate ?? notImplemented),
     },
     provider: {
-      add: withCallCount(impl.provider?.add ?? notImplemented)
-    }
+      add: withCallCount(impl.provider?.add ?? notImplemented),
+    },
   }
 }
 
@@ -46,7 +48,7 @@ export function mockService (impl) {
  * @template {Function} T
  * @param {T} fn
  */
-function withCallCount (fn) {
+function withCallCount(fn) {
   /** @param {T extends (...args: infer A) => any ? A : never} args */
   const countedFn = (...args) => {
     countedFn.called = true
@@ -61,12 +63,12 @@ function withCallCount (fn) {
 /**
  * @param {import('@ucanto/interface').ServerView} server
  */
-export async function mockServiceConf (server) {
+export async function mockServiceConf(server) {
   const connection = connect({
     id: server.id,
     encoder: CAR,
     decoder: CBOR,
-    channel: server
+    channel: server,
   })
   return { access: connection, upload: connection }
 }

--- a/packages/w3up-client/test/helpers/random.js
+++ b/packages/w3up-client/test/helpers/random.js
@@ -1,22 +1,22 @@
 import { toCAR } from './car.js'
 
 /** @param {number} size */
-export async function randomBytes (size) {
+export async function randomBytes(size) {
   const bytes = new Uint8Array(size)
   while (size) {
     const chunk = new Uint8Array(Math.min(size, 65_536))
-    if (!globalThis.crypto) {
+    if (globalThis.crypto) {
+      crypto.getRandomValues(chunk)
+    } else {
       try {
         const { webcrypto } = await import('node:crypto')
         webcrypto.getRandomValues(chunk)
-      } catch (err) {
+      } catch (error) {
         throw new Error(
           'unknown environment - no global crypto and not Node.js',
-          { cause: err }
+          { cause: error }
         )
       }
-    } else {
-      crypto.getRandomValues(chunk)
     }
     size -= bytes.length
     bytes.set(chunk, size)
@@ -25,7 +25,7 @@ export async function randomBytes (size) {
 }
 
 /** @param {number} size */
-export async function randomCAR (size) {
+export async function randomCAR(size) {
   const bytes = await randomBytes(size)
   return toCAR(bytes)
 }

--- a/packages/w3up-client/test/helpers/shims.js
+++ b/packages/w3up-client/test/helpers/shims.js
@@ -3,7 +3,7 @@ export class File extends Blob {
    * @param {BlobPart[]} blobParts
    * @param {string} name
    */
-  constructor (blobParts, name) {
+  constructor(blobParts, name) {
     super(blobParts)
     this.name = name
   }

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -4,10 +4,10 @@
     "outDir": "dist",
     "emitDeclarationOnly": true,
     "composite": true,
-    "noUnusedParameters": false,
+    "noUnusedParameters": false
   },
   "include": [
-    "./src",
+    "./src"
     // @todo add "./test",
   ],
   "typedocOptions": {
@@ -17,7 +17,7 @@
     "navigationLinks": {
       "Github": "https://github.com/web3-storage/w3up-client"
     },
-    "customCss": "./static/docs.css",
+    "customCss": "./static/docs.css"
   },
   "references": [
     { "path": "../access-client" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,7 @@ importers:
       assert: ^2.0.0
       c8: ^7.13.0
       docusaurus-plugin-typedoc: ^0.18.0
+      hd-scripts: ^5.0.0
       hundreds: ^0.0.9
       mocha: ^10.1.0
       multiformats: ^11.0.0
@@ -368,6 +369,7 @@ importers:
       assert: 2.0.0
       c8: 7.13.0
       docusaurus-plugin-typedoc: 0.18.0_bhwftghzp2kjaeaba4ticsx7k4
+      hd-scripts: 5.0.0
       hundreds: 0.0.9
       mocha: 10.2.0
       multiformats: 11.0.2
@@ -2027,6 +2029,15 @@ packages:
       jsdoc-type-pratt-parser: 3.1.0
     dev: true
 
+  /@es-joy/jsdoccomment/0.37.0:
+    resolution: {integrity: sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==}
+    engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
+    dependencies:
+      comment-parser: 1.3.1
+      esquery: 1.5.0
+      jsdoc-type-pratt-parser: 4.0.0
+    dev: true
+
   /@esbuild-plugins/node-globals-polyfill/0.1.1_esbuild@0.16.3:
     resolution: {integrity: sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==}
     peerDependencies:
@@ -2649,13 +2660,28 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@eslint-community/eslint-utils/4.4.0_eslint@8.36.0:
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.36.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@eslint-community/regexpp/4.4.1:
+    resolution: {integrity: sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
   /@eslint/eslintrc/1.4.1:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.4.1
+      espree: 9.5.0
       globals: 13.20.0
       ignore: 5.2.4
       import-fresh: 3.3.0
@@ -2664,6 +2690,28 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@eslint/eslintrc/2.0.1:
+    resolution: {integrity: sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 9.5.0
+      globals: 13.20.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@eslint/js/8.36.0:
+    resolution: {integrity: sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@hapi/hoek/9.3.0:
@@ -3083,7 +3131,7 @@ packages:
     peerDependencies:
       typescript: ^3 || ^4
     dependencies:
-      esquery: 1.4.0
+      esquery: 1.5.0
       typescript: 4.9.5
     dev: true
 
@@ -3653,12 +3701,6 @@ packages:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
     dev: true
 
-  /@types/yargs/17.0.22:
-    resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
-    dependencies:
-      '@types/yargs-parser': 21.0.0
-    dev: true
-
   /@types/yargs/17.0.23:
     resolution: {integrity: sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==}
     dependencies:
@@ -3693,6 +3735,34 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin/5.57.0_5t5646cukn2kik5kiydglap3vi:
+    resolution: {integrity: sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.4.1
+      '@typescript-eslint/parser': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      '@typescript-eslint/scope-manager': 5.57.0
+      '@typescript-eslint/type-utils': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      '@typescript-eslint/utils': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      debug: 4.3.4
+      eslint: 8.36.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/experimental-utils/5.50.0_4vsywjlpuriuw3tl5oq6zy5a64:
     resolution: {integrity: sha512-gZIhzNRivy0RVqcxjKnQ+ipGc0qolilhBeNmvH+Dvu7Vymug+IfiYxTj2zM7mIlHsw6Q5aH7L7WmuTE3tZyzag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3701,6 +3771,19 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 5.50.0_4vsywjlpuriuw3tl5oq6zy5a64
       eslint: 8.33.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/experimental-utils/5.50.0_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-gZIhzNRivy0RVqcxjKnQ+ipGc0qolilhBeNmvH+Dvu7Vymug+IfiYxTj2zM7mIlHsw6Q5aH7L7WmuTE3tZyzag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.50.0_vgl77cfdswitgr47lm5swmv43m
+      eslint: 8.36.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3726,12 +3809,40 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/5.57.0_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.57.0
+      '@typescript-eslint/types': 5.57.0
+      '@typescript-eslint/typescript-estree': 5.57.0_typescript@4.9.5
+      debug: 4.3.4
+      eslint: 8.36.0
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager/5.50.0:
     resolution: {integrity: sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.50.0
       '@typescript-eslint/visitor-keys': 5.50.0
+    dev: true
+
+  /@typescript-eslint/scope-manager/5.57.0:
+    resolution: {integrity: sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.57.0
+      '@typescript-eslint/visitor-keys': 5.57.0
     dev: true
 
   /@typescript-eslint/type-utils/5.50.0_4vsywjlpuriuw3tl5oq6zy5a64:
@@ -3754,8 +3865,33 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils/5.57.0_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.57.0_typescript@4.9.5
+      '@typescript-eslint/utils': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      debug: 4.3.4
+      eslint: 8.36.0
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types/5.50.0:
     resolution: {integrity: sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.57.0:
+    resolution: {integrity: sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -3770,6 +3906,27 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.50.0
       '@typescript-eslint/visitor-keys': 5.50.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.57.0_typescript@4.9.5:
+    resolution: {integrity: sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.57.0
+      '@typescript-eslint/visitor-keys': 5.57.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -3800,11 +3957,59 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.50.0_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.50.0
+      '@typescript-eslint/types': 5.50.0
+      '@typescript-eslint/typescript-estree': 5.50.0_typescript@4.9.5
+      eslint: 8.36.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.36.0
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils/5.57.0_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.36.0
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.57.0
+      '@typescript-eslint/types': 5.57.0
+      '@typescript-eslint/typescript-estree': 5.57.0_typescript@4.9.5
+      eslint: 8.36.0
+      eslint-scope: 5.1.1
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.50.0:
     resolution: {integrity: sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.50.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.57.0:
+    resolution: {integrity: sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.57.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -6161,6 +6366,15 @@ packages:
       eslint: 8.33.0
     dev: true
 
+  /eslint-config-prettier/8.8.0_eslint@8.36.0:
+    resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.36.0
+    dev: true
+
   /eslint-config-standard-jsx/11.0.0_qfmo47wux3a6s5vhwqly27hd6u:
     resolution: {integrity: sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==}
     peerDependencies:
@@ -6193,6 +6407,42 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-config-standard-with-typescript/34.0.1_jo4jc4suruallj56mai7w4wzte:
+    resolution: {integrity: sha512-J7WvZeLtd0Vr9F+v4dZbqJCLD16cbIy4U+alJMq4MiXdpipdBM3U5NkXaGUjePc4sb1ZE01U9g6VuTBpHHz1fg==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.43.0
+      eslint: ^8.0.1
+      eslint-plugin-import: ^2.25.2
+      eslint-plugin-n: ^15.0.0
+      eslint-plugin-promise: ^6.0.0
+      typescript: '*'
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.57.0_5t5646cukn2kik5kiydglap3vi
+      '@typescript-eslint/parser': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      eslint: 8.36.0
+      eslint-config-standard: 17.0.0_htxjg2emk4phzexndh6sfdkv2u
+      eslint-plugin-import: 2.27.5_74llxljztmzze2ez7aakaiqyti
+      eslint-plugin-n: 15.6.1_eslint@8.36.0
+      eslint-plugin-promise: 6.1.1_eslint@8.36.0
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-config-standard/17.0.0_htxjg2emk4phzexndh6sfdkv2u:
+    resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
+    peerDependencies:
+      eslint: ^8.0.1
+      eslint-plugin-import: ^2.25.2
+      eslint-plugin-n: ^15.0.0
+      eslint-plugin-promise: ^6.0.0
+    dependencies:
+      eslint: 8.36.0
+      eslint-plugin-import: 2.27.5_74llxljztmzze2ez7aakaiqyti
+      eslint-plugin-n: 15.6.1_eslint@8.36.0
+      eslint-plugin-promise: 6.1.1_eslint@8.36.0
+    dev: true
+
   /eslint-config-standard/17.0.0_xh3wrndcszbt2l7hdksdjqnjcq:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
@@ -6202,7 +6452,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.33.0
-      eslint-plugin-import: 2.27.5_ufewo3pl5nnmz6lltvjrdi2hii
+      eslint-plugin-import: 2.27.5_eslint@8.33.0
       eslint-plugin-n: 15.6.1_eslint@8.33.0
       eslint-plugin-promise: 6.1.1_eslint@8.33.0
     dev: true
@@ -6215,6 +6465,21 @@ packages:
     dependencies:
       '@typescript-eslint/experimental-utils': 5.50.0_4vsywjlpuriuw3tl5oq6zy5a64
       eslint: 8.33.0
+      tsutils: 3.21.0_typescript@4.9.5
+      tsutils-etc: 1.4.1_dw2ve3pa3py4wrhanasku2jsqi
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-etc/5.2.0_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-Gcm/NMa349FOXb1PEEfNMMyIANuorIc2/mI5Vfu1zENNsz+FBVhF62uY6gPUCigm/xDOc8JOnl+71WGnlzlDag==}
+    peerDependencies:
+      eslint: ^8.0.0
+      typescript: ^4.0.0
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.50.0_vgl77cfdswitgr47lm5swmv43m
+      eslint: 8.36.0
       tsutils: 3.21.0_typescript@4.9.5
       tsutils-etc: 1.4.1_dw2ve3pa3py4wrhanasku2jsqi
       typescript: 4.9.5
@@ -6260,6 +6525,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils/2.7.4_s7ttrvgfvhhasgm2z4wjvde2bi:
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      debug: 3.2.7
+      eslint: 8.36.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-module-utils/2.7.4_ypqpzq5szckeh62pb722iz7nn4:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
@@ -6300,6 +6594,17 @@ packages:
       regexpp: 3.2.0
     dev: true
 
+  /eslint-plugin-es/4.1.0_eslint@8.36.0:
+    resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
+    engines: {node: '>=8.10.0'}
+    peerDependencies:
+      eslint: '>=4.19.1'
+    dependencies:
+      eslint: 8.36.0
+      eslint-utils: 2.1.0
+      regexpp: 3.2.0
+    dev: true
+
   /eslint-plugin-etc/2.0.2_4vsywjlpuriuw3tl5oq6zy5a64:
     resolution: {integrity: sha512-g3b95LCdTCwZA8On9EICYL8m1NMWaiGfmNUd/ftZTeGZDXrwujKXUr+unYzqKjKFo1EbqJ31vt+Dqzrdm/sUcw==}
     peerDependencies:
@@ -6315,6 +6620,57 @@ packages:
       tsutils: 3.21.0_typescript@4.9.5
       typescript: 4.9.5
     transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-etc/2.0.2_vgl77cfdswitgr47lm5swmv43m:
+    resolution: {integrity: sha512-g3b95LCdTCwZA8On9EICYL8m1NMWaiGfmNUd/ftZTeGZDXrwujKXUr+unYzqKjKFo1EbqJ31vt+Dqzrdm/sUcw==}
+    peerDependencies:
+      eslint: ^8.0.0
+      typescript: ^4.0.0
+    dependencies:
+      '@phenomnomnominal/tsquery': 4.2.0_typescript@4.9.5
+      '@typescript-eslint/experimental-utils': 5.50.0_vgl77cfdswitgr47lm5swmv43m
+      eslint: 8.36.0
+      eslint-etc: 5.2.0_vgl77cfdswitgr47lm5swmv43m
+      requireindex: 1.2.0
+      tslib: 2.5.0
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import/2.27.5_74llxljztmzze2ez7aakaiqyti:
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.36.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.7.4_s7ttrvgfvhhasgm2z4wjvde2bi
+      has: 1.0.3
+      is-core-module: 2.11.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.1
+      semver: 6.3.0
+      tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
@@ -6401,6 +6757,24 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-plugin-jsdoc/40.1.0_eslint@8.36.0:
+    resolution: {integrity: sha512-ANvrhiu62VlSorARM0hup60VQsS3hNyp0Ca7cnJDj8tpJzM7tNhBVqMVYXSuLzEmqrpwx6aAh+NAN2DdAGG5fQ==}
+    engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@es-joy/jsdoccomment': 0.37.0
+      comment-parser: 1.3.1
+      debug: 4.3.4
+      escape-string-regexp: 4.0.0
+      eslint: 8.36.0
+      esquery: 1.5.0
+      semver: 7.3.8
+      spdx-expression-parse: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-n/15.6.1_eslint@8.33.0:
     resolution: {integrity: sha512-R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==}
     engines: {node: '>=12.22.0'}
@@ -6411,6 +6785,23 @@ packages:
       eslint: 8.33.0
       eslint-plugin-es: 4.1.0_eslint@8.33.0
       eslint-utils: 3.0.0_eslint@8.33.0
+      ignore: 5.2.4
+      is-core-module: 2.11.0
+      minimatch: 3.1.2
+      resolve: 1.22.1
+      semver: 7.3.8
+    dev: true
+
+  /eslint-plugin-n/15.6.1_eslint@8.36.0:
+    resolution: {integrity: sha512-R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      builtins: 5.0.1
+      eslint: 8.36.0
+      eslint-plugin-es: 4.1.0_eslint@8.36.0
+      eslint-utils: 3.0.0_eslint@8.36.0
       ignore: 5.2.4
       is-core-module: 2.11.0
       minimatch: 3.1.2
@@ -6432,6 +6823,15 @@ packages:
       eslint: 8.33.0
     dev: true
 
+  /eslint-plugin-promise/6.1.1_eslint@8.36.0:
+    resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.36.0
+    dev: true
+
   /eslint-plugin-react-hooks/4.6.0_eslint@8.33.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -6439,6 +6839,15 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.33.0
+    dev: true
+
+  /eslint-plugin-react-hooks/4.6.0_eslint@8.36.0:
+    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.36.0
     dev: true
 
   /eslint-plugin-react/7.32.2_eslint@8.33.0:
@@ -6465,6 +6874,30 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
+  /eslint-plugin-react/7.32.2_eslint@8.36.0:
+    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
+      array.prototype.tosorted: 1.1.1
+      doctrine: 2.1.0
+      eslint: 8.36.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.3
+      minimatch: 3.1.2
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
+      object.hasown: 1.1.2
+      object.values: 1.1.6
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.4
+      semver: 6.3.0
+      string.prototype.matchall: 4.0.8
+    dev: true
+
   /eslint-plugin-unicorn/45.0.2_eslint@8.33.0:
     resolution: {integrity: sha512-Y0WUDXRyGDMcKLiwgL3zSMpHrXI00xmdyixEGIg90gHnj0PcHY4moNv3Ppje/kDivdAy5vUeUr7z211ImPv2gw==}
     engines: {node: '>=14.18'}
@@ -6477,6 +6910,31 @@ packages:
       clean-regexp: 1.0.0
       eslint: 8.33.0
       esquery: 1.4.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.1
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      read-pkg-up: 7.0.1
+      regexp-tree: 0.1.24
+      regjsparser: 0.9.1
+      safe-regex: 2.1.1
+      semver: 7.3.8
+      strip-indent: 3.0.0
+    dev: true
+
+  /eslint-plugin-unicorn/46.0.0_eslint@8.36.0:
+    resolution: {integrity: sha512-j07WkC+PFZwk8J33LYp6JMoHa1lXc1u6R45pbSAipjpfpb7KIGr17VE2D685zCxR5VL4cjrl65kTJflziQWMDA==}
+    engines: {node: '>=14.18'}
+    peerDependencies:
+      eslint: '>=8.28.0'
+    dependencies:
+      '@babel/helper-validator-identifier': 7.19.1
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.36.0
+      ci-info: 3.8.0
+      clean-regexp: 1.0.0
+      eslint: 8.36.0
+      esquery: 1.5.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.1
       jsesc: 3.0.2
@@ -6523,6 +6981,16 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: true
 
+  /eslint-utils/3.0.0_eslint@8.36.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 8.36.0
+      eslint-visitor-keys: 2.1.0
+    dev: true
+
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
     engines: {node: '>=4'}
@@ -6556,8 +7024,8 @@ packages:
       eslint-scope: 7.1.1
       eslint-utils: 3.0.0_eslint@8.33.0
       eslint-visitor-keys: 3.3.0
-      espree: 9.4.1
-      esquery: 1.4.0
+      espree: 9.5.0
+      esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
@@ -6586,8 +7054,57 @@ packages:
       - supports-color
     dev: true
 
-  /espree/9.4.1:
-    resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
+  /eslint/8.36.0:
+    resolution: {integrity: sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.36.0
+      '@eslint-community/regexpp': 4.4.1
+      '@eslint/eslintrc': 2.0.1
+      '@eslint/js': 8.36.0
+      '@humanwhocodes/config-array': 0.11.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.1.1
+      eslint-visitor-keys: 3.3.0
+      espree: 9.5.0
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.20.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-sdsl: 4.3.0
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /espree/9.5.0:
+    resolution: {integrity: sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.2
@@ -6602,6 +7119,13 @@ packages:
 
   /esquery/1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /esquery/1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -7496,6 +8020,36 @@ packages:
       - supports-color
     dev: true
 
+  /hd-scripts/5.0.0:
+    resolution: {integrity: sha512-wFecqDH+tW/Ajg993eFGLe1i7rVGrZkSZv1Zitsj3dGnvURLa/+Up+L46+MPFFCq7qhwBLoooL/Rs3cpjqbTVg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.57.0_5t5646cukn2kik5kiydglap3vi
+      '@typescript-eslint/parser': 5.57.0_vgl77cfdswitgr47lm5swmv43m
+      eslint: 8.36.0
+      eslint-config-prettier: 8.8.0_eslint@8.36.0
+      eslint-config-standard: 17.0.0_htxjg2emk4phzexndh6sfdkv2u
+      eslint-config-standard-with-typescript: 34.0.1_jo4jc4suruallj56mai7w4wzte
+      eslint-plugin-etc: 2.0.2_vgl77cfdswitgr47lm5swmv43m
+      eslint-plugin-import: 2.27.5_74llxljztmzze2ez7aakaiqyti
+      eslint-plugin-jsdoc: 40.1.0_eslint@8.36.0
+      eslint-plugin-n: 15.6.1_eslint@8.36.0
+      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-promise: 6.1.1_eslint@8.36.0
+      eslint-plugin-react: 7.32.2_eslint@8.36.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.36.0
+      eslint-plugin-unicorn: 46.0.0_eslint@8.36.0
+      lint-staged: 13.2.0
+      prettier: 2.8.7
+      simple-git-hooks: 2.8.1
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - enquirer
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -8370,6 +8924,11 @@ packages:
 
   /jsdoc-type-pratt-parser/3.1.0:
     resolution: {integrity: sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
+  /jsdoc-type-pratt-parser/4.0.0:
+    resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
     engines: {node: '>=12.0.0'}
     dev: true
 
@@ -10266,6 +10825,12 @@ packages:
     hasBin: true
     dev: true
 
+  /prettier/2.8.7:
+    resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
   /pretty-error/4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
     dependencies:
@@ -11958,7 +12523,7 @@ packages:
       tsutils: ^3.0.0
       typescript: ^4.0.0
     dependencies:
-      '@types/yargs': 17.0.22
+      '@types/yargs': 17.0.23
       tsutils: 3.21.0_typescript@4.9.5
       typescript: 4.9.5
       yargs: 17.6.2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
       "packages/access-client",
       "packages/capabilities",
       "packages/upload-client",
-      "packages/w3up-client",
+      "packages/w3up-client"
     ],
     "excludeExternals": true,
     "darkHighlightTheme": "github-dark",


### PR DESCRIPTION
make it consistent with other packages in this monorepo so that the top level prettier format command doesn't make unexpected changes when trying to format other packages