### PR TITLE
test: w3up-client tsconfig.json now includes "./test" so its tests have some type checking

### DIFF
--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -85,6 +85,7 @@
   "devDependencies": {
     "@docusaurus/core": "^2.2.0",
     "@ipld/car": "^5.1.1",
+    "@types/mocha": "^10.0.1",
     "@ucanto/server": "^6.1.0",
     "assert": "^2.0.0",
     "c8": "^7.13.0",

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -134,7 +134,9 @@ export class Client extends Base {
    * Spaces available to this agent.
    */
   spaces() {
-    return [...this._agent.spaces].map(([did, meta]) => new Space(did, meta))
+    return [...this._agent.spaces].map(([did, meta]) => {
+      return new Space(/** @type {`did:key:${string}`} */ (did), meta)
+    })
   }
 
   /**
@@ -171,7 +173,7 @@ export class Client extends Base {
    */
   async addSpace(proof) {
     const { did, meta } = await this._agent.importSpaceFromDelegation(proof)
-    return new Space(did, meta)
+    return new Space(/** @type {`did:key:${string}`} */ (did), meta)
   }
 
   /**

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -124,10 +124,10 @@ export class Client extends Base {
   /**
    * Use a specific space.
    *
-   * @param {import('./types').DID<'key'>} did
+   * @param {import('./types').DID} did
    */
   async setCurrentSpace(did) {
-    await this._agent.setCurrentSpace(did)
+    await this._agent.setCurrentSpace(/** @type {`did:key:${string}`} */ (did))
   }
 
   /**
@@ -135,7 +135,7 @@ export class Client extends Base {
    */
   spaces() {
     return [...this._agent.spaces].map(([did, meta]) => {
-      return new Space(/** @type {`did:key:${string}`} */ (did), meta)
+      return new Space(did, meta)
     })
   }
 
@@ -173,7 +173,7 @@ export class Client extends Base {
    */
   async addSpace(proof) {
     const { did, meta } = await this._agent.importSpaceFromDelegation(proof)
-    return new Space(/** @type {`did:key:${string}`} */ (did), meta)
+    return new Space(did, meta)
   }
 
   /**

--- a/packages/w3up-client/src/space.js
+++ b/packages/w3up-client/src/space.js
@@ -1,11 +1,11 @@
 export class Space {
-  /** @type {import('./types').DID} */
+  /** @type {import('./types').DID<'key'>} */
   #did
   /** @type {Record<string, any>} */
   #meta
 
   /**
-   * @param {import('./types').DID} did
+   * @param {import('./types').DID<'key'>} did
    * @param {Record<string, any>} meta
    */
   constructor(did, meta = {}) {

--- a/packages/w3up-client/src/space.js
+++ b/packages/w3up-client/src/space.js
@@ -1,11 +1,11 @@
 export class Space {
-  /** @type {import('./types').DID<'key'>} */
+  /** @type {import('./types').DID} */
   #did
   /** @type {Record<string, any>} */
   #meta
 
   /**
-   * @param {import('./types').DID<'key'>} did
+   * @param {import('./types').DID} did
    * @param {Record<string, any>} meta
    */
   constructor(did, meta = {}) {

--- a/packages/w3up-client/test/capability/access.test.js
+++ b/packages/w3up-client/test/capability/access.test.js
@@ -19,7 +19,7 @@ describe('AccessClient', () => {
             const invCap = invocation.capabilities[0]
             assert.equal(invCap.can, AccessCapabilities.claim.can)
             return {
-              delegations: [],
+              delegations: {},
             }
           }),
         },
@@ -33,6 +33,7 @@ describe('AccessClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -20,7 +20,7 @@ describe('SpaceClient', () => {
             assert.equal(invCap.can, SpaceCapabilities.info.can)
             assert.equal(invCap.with, space.did())
             return {
-              did: space.did(),
+              did: /** @type {`did:key:${string}`} */ (space.did()),
             }
           }),
         },

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -21,11 +21,6 @@ describe('SpaceClient', () => {
             assert.equal(invCap.with, space.did())
             return {
               did: space.did(),
-              agent: alice.agent().did(),
-              email: 'mailto:alice@example.com',
-              product: 'product:test',
-              updated_at: '',
-              inserted_at: '',
             }
           }),
         },
@@ -39,6 +34,7 @@ describe('SpaceClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -51,9 +47,6 @@ describe('SpaceClient', () => {
       assert.equal(service.space.info.callCount, 1)
 
       assert.equal(info.did, space.did())
-      assert.equal(info.agent, alice.agent().did())
-      assert.equal(info.email, 'mailto:alice@example.com')
-      assert.equal(info.product, 'product:test')
     })
   })
 })

--- a/packages/w3up-client/test/capability/store.test.js
+++ b/packages/w3up-client/test/capability/store.test.js
@@ -24,6 +24,8 @@ describe('StoreClient', () => {
               status: 'upload',
               headers: { 'x-test': 'true' },
               url: 'http://localhost:9200',
+              link: car.cid,
+              with: space.did(),
             }
           }),
         },
@@ -37,6 +39,7 @@ describe('StoreClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -88,6 +91,7 @@ describe('StoreClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -130,6 +134,7 @@ describe('StoreClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -43,6 +43,7 @@ describe('StoreClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -92,6 +93,7 @@ describe('StoreClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -121,7 +123,8 @@ describe('StoreClient', () => {
             const invCap = invocation.capabilities[0]
             assert.equal(invCap.can, UploadCapabilities.remove.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
-            return null
+            // eslint-disable-next-line unicorn/no-useless-undefined
+            return undefined
           }),
         },
       })
@@ -134,6 +137,7 @@ describe('StoreClient', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -34,6 +34,10 @@ describe('Client', () => {
               status: 'upload',
               headers: { 'x-test': 'true' },
               url: 'http://localhost:9200',
+              link: /** @type {import('@web3-storage/upload-client/types').CARLink} */ (
+                invocation.capabilities[0].nb?.link
+              ),
+              with: space.did(),
             }
           }),
         },
@@ -62,6 +66,7 @@ describe('Client', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -118,6 +123,10 @@ describe('Client', () => {
               status: 'upload',
               headers: { 'x-test': 'true' },
               url: 'http://localhost:9200',
+              link: /** @type {import('@web3-storage/upload-client/types').CARLink} */ (
+                invocation.capabilities[0].nb?.link
+              ),
+              with: space.did(),
             }
           }),
         },
@@ -143,6 +152,7 @@ describe('Client', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -184,6 +194,10 @@ describe('Client', () => {
               status: 'upload',
               headers: { 'x-test': 'true' },
               url: 'http://localhost:9200',
+              link: /** @type {import('@web3-storage/upload-client/types').CARLink} */ (
+                invocation.capabilities[0].nb?.link
+              ),
+              with: space.did(),
             }
           }),
         },
@@ -196,7 +210,8 @@ describe('Client', () => {
             assert.equal(invCap.with, space.did())
             if (!invCap.nb) throw new Error('nb must be present')
             assert.equal(invCap.nb.shards?.length, 1)
-            assert.equal(invCap.nb.shards[0].toString(), carCID.toString())
+            assert.ok(carCID)
+            assert.equal(invCap.nb.shards?.[0].toString(), carCID.toString())
             return invCap.nb
           }),
         },
@@ -210,6 +225,7 @@ describe('Client', () => {
       })
 
       const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
         serviceConf: await mockServiceConf(server),
       })
 
@@ -225,9 +241,6 @@ describe('Client', () => {
       assert.equal(service.store.add.callCount, 1)
       assert(service.upload.add.called)
       assert.equal(service.upload.add.callCount, 1)
-
-      assert(carCID)
-      assert.equal(carCID.toString(), car.cid.toString())
     })
   })
 

--- a/packages/w3up-client/test/helpers/mocks.js
+++ b/packages/w3up-client/test/helpers/mocks.js
@@ -9,6 +9,8 @@ const notImplemented = () => {
 
 /**
  * @param {Partial<{
+ * access: Partial<import('@web3-storage/access/types').Service['access']>
+ * provider: Partial<import('@web3-storage/access/types').Service['provider']>
  * store: Partial<import('@web3-storage/upload-client/types').Service['store']>
  * upload: Partial<import('@web3-storage/upload-client/types').Service['upload']>
  * voucher: Partial<import('@web3-storage/access/types').Service['voucher']>
@@ -61,7 +63,8 @@ function withCallCount(fn) {
 }
 
 /**
- * @param {import('@ucanto/interface').ServerView} server
+ * @template {Record<string, any>} Service - describes methods exposed via ucanto server
+ * @param {import('@ucanto/interface').ServerView<Service>} server
  */
 export async function mockServiceConf(server) {
   const connection = connect({

--- a/packages/w3up-client/test/helpers/mocks.js
+++ b/packages/w3up-client/test/helpers/mocks.js
@@ -63,7 +63,8 @@ function withCallCount(fn) {
 }
 
 /**
- * @template {Record<string, any>} Service - describes methods exposed via ucanto server
+ * @template {string} K
+ * @template {Record<K, any>} Service - describes methods exposed via ucanto server
  * @param {import('@ucanto/interface').ServerView<Service>} server
  */
 export async function mockServiceConf(server) {

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -9,8 +9,7 @@
   "include": [
     "./src",
     // @todo add "./test",
-    "./test/capability/access.test.js",
-    "./test/capability/space.test.js",
+    "./test/capability",
     "./test/helpers"
   ],
   "typedocOptions": {

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -9,7 +9,9 @@
   "include": [
     "./src",
     // @todo add "./test",
-    "./test/helpers",
+    "./test/capability/access.test.js",
+    "./test/capability/space.test.js",
+    "./test/helpers"
   ],
   "typedocOptions": {
     "entryPoints": ["./src"],

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -6,13 +6,7 @@
     "composite": true,
     "noUnusedParameters": false
   },
-  "include": [
-    "./src",
-    // @todo add "./test",
-    "./test/capability",
-    "./test/helpers",
-    "./test/client.test.js"
-  ],
+  "include": ["./src", "./test"],
   "typedocOptions": {
     "entryPoints": ["./src"],
     "entryPointStrategy": "expand",

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -7,8 +7,9 @@
     "noUnusedParameters": false
   },
   "include": [
-    "./src"
+    "./src",
     // @todo add "./test",
+    "./test/helpers",
   ],
   "typedocOptions": {
     "entryPoints": ["./src"],

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -10,7 +10,8 @@
     "./src",
     // @todo add "./test",
     "./test/capability",
-    "./test/helpers"
+    "./test/helpers",
+    "./test/client.test.js"
   ],
   "typedocOptions": {
     "entryPoints": ["./src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,7 @@ importers:
       '@docusaurus/core': ^2.2.0
       '@ipld/car': ^5.1.1
       '@ipld/dag-ucan': ^3.0.1
+      '@types/mocha': ^10.0.1
       '@ucanto/client': ^5.1.0
       '@ucanto/core': ^5.1.0
       '@ucanto/interface': ^6.0.0
@@ -365,6 +366,7 @@ importers:
     devDependencies:
       '@docusaurus/core': 2.3.1_typescript@4.9.5
       '@ipld/car': 5.1.1
+      '@types/mocha': 10.0.1
       '@ucanto/server': 6.1.0
       assert: 2.0.0
       c8: 7.13.0


### PR DESCRIPTION
Non-goal
* changing src code
* avoidance of all ts-ignore in these newly included files (that can come as iteration)

Context:
* https://github.com/web3-storage/w3protocol/issues/668#issuecomment-1485989307