### PR TITLE
fix: verify proofs exist for requested delegation capabilities

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -109,6 +109,7 @@
       "unicorn/prefer-number-properties": "off",
       "unicorn/prefer-export-from": "off",
       "unicorn/no-array-reduce": "off",
+      "unicorn/explicit-length-check": "off",
       "jsdoc/no-undefined-types": [
         "error",
         {

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -545,7 +545,7 @@ export class Agent {
   async delegate(options) {
     const space = this.currentSpaceWithMeta()
     if (!space) {
-      throw new Error('there no space selected.')
+      throw new Error('no space selected.')
     }
 
     const caps = /** @type {Ucanto.Capabilities} */ (
@@ -557,11 +557,18 @@ export class Agent {
       })
     )
 
+    // Verify agent can provide proofs for each requested capability
+    for (const cap of caps) {
+      if (!this.proofs([cap]).length) {
+        throw new Error(`cannot delegate capability ${cap.can} with ${cap.with}`)
+      }
+    }
+
     const delegation = await delegate({
       issuer: this.issuer,
       capabilities: caps,
       proofs: this.proofs(caps),
-      facts: [{ space: space.meta }],
+      facts: [{ space: space.meta ?? {} }],
       ...options,
     })
 

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -560,7 +560,9 @@ export class Agent {
     // Verify agent can provide proofs for each requested capability
     for (const cap of caps) {
       if (!this.proofs([cap]).length) {
-        throw new Error(`cannot delegate capability ${cap.can} with ${cap.with}`)
+        throw new Error(
+          `cannot delegate capability ${cap.can} with ${cap.with}`
+        )
       }
     }
 

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -181,6 +181,37 @@ describe('Agent', function () {
     ])
   })
 
+  it('should not create delegation without proof', async function () {
+    const server = createServer()
+    const alice = await Agent.create(undefined, {
+      connection: connection({ channel: server }),
+    })
+    const bob = await Agent.create(undefined, {
+      connection: connection({ channel: server }),
+    })
+
+    const space = await alice.createSpace('execute')
+    await alice.setCurrentSpace(space.did)
+
+    const delegation = await alice.delegate({
+      abilities: ['space/info'],
+      audience: bob,
+      audienceMeta: { name: 'sss', type: 'app' },
+    })
+
+    await bob.addProof(delegation)
+    await bob.setCurrentSpace(space.did)
+
+    // should not be able to store/remove - bob only has ability to space/info
+    await assert.rejects(() => (
+      bob.delegate({
+        abilities: ['store/remove'],
+        audience: fixtures.mallory,
+        audienceMeta: { name: 'sss', type: 'app' },
+      })
+    ), /cannot delegate capability store\/remove/)
+  })
+
   it('exports createDidMailtoFromEmail', async () => {
     assert.deepEqual(
       createDidMailtoFromEmail('foo@dag.house'),

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -203,13 +203,15 @@ describe('Agent', function () {
     await bob.setCurrentSpace(space.did)
 
     // should not be able to store/remove - bob only has ability to space/info
-    await assert.rejects(() => (
-      bob.delegate({
-        abilities: ['store/remove'],
-        audience: fixtures.mallory,
-        audienceMeta: { name: 'sss', type: 'app' },
-      })
-    ), /cannot delegate capability store\/remove/)
+    await assert.rejects(
+      () =>
+        bob.delegate({
+          abilities: ['store/remove'],
+          audience: fixtures.mallory,
+          audienceMeta: { name: 'sss', type: 'app' },
+        }),
+      /cannot delegate capability store\/remove/
+    )
   })
 
   it('exports createDidMailtoFromEmail', async () => {


### PR DESCRIPTION
Previously `this.proofs(caps)` was returning `[]` when you request capabilities the agent is not authorized to use, the call to `delegate` would succeed and you get a useless delegation because there are no proofs.