### PR TITLE
fix: default authorization abilities

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -191,11 +191,7 @@ export async function authorizeAndWait(access, email, opts) {
       })
     }
   const account = { did: () => createDidMailtoFromEmail(email) }
-  await requestAccess(
-    access,
-    account,
-    opts?.capabilities || [{ can: '*' }]
-  )
+  await requestAccess(access, account, opts?.capabilities || [{ can: '*' }])
   const sessionDelegations = [...(await expectAuthorization())]
   if (!opts?.dontAddProofs) {
     await Promise.all(sessionDelegations.map(async (d) => access.addProof(d)))

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -194,12 +194,7 @@ export async function authorizeAndWait(access, email, opts) {
   await requestAccess(
     access,
     account,
-    opts?.capabilities || [
-      { can: 'space/*' },
-      { can: 'store/*' },
-      { can: 'provider/add' },
-      { can: 'upload/*' },
-    ]
+    opts?.capabilities || [{ can: '*' }]
   )
   const sessionDelegations = [...(await expectAuthorization())]
   if (!opts?.dontAddProofs) {

--- a/packages/w3up-client/src/capability/access.js
+++ b/packages/w3up-client/src/capability/access.js
@@ -13,6 +13,7 @@ export class AccessClient extends Base {
    * @param {`${string}@${string}`} email
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
+   * @param {Iterable<{ can: import('../types').Ability }>} [options.capabilities]
    */
   async authorize(email, options) {
     return authorizeWithSocket(this._agent, email, options)

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -39,6 +39,7 @@ export class Client extends Base {
    * @param {`${string}@${string}`} email
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
+   * @param {Iterable<{ can: import('./types').Ability }>} [options.capabilities]
    */
   async authorize(email, options) {
     await this.capability.access.authorize(email, options)


### PR DESCRIPTION
Until we lift the restriction that we cannot add a space that we don't have admin access (`*`) over please can we default to allowing admin access when we authorize a space?